### PR TITLE
fix: bump waldoctl pin to v0.4.0 (repairs red main)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.2.0",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.4.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
**Fixes `main`'s red CI.** The panels merge (#20) landed parol6 code that imports `CameraSpec` and `ToolsCollection` from waldoctl, but `main` still pinned `waldoctl@v0.2.0` (has neither; `v0.3.0` was tagged before `ToolsCollection`). This bumps the pin to the new **`waldoctl@v0.4.0`** tag, which has both.

Verified: with v0.4.0, `parol6.Robot()` instantiates and all waldoctl imports resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
