### PR TITLE
ci: scope push trigger to main (kill duplicate PR-branch runs)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   workflow_dispatch:
+  # Scope push to main only — PR branches are covered by pull_request, so this
+  # avoids a redundant second run (and the "re-ran one, the twin still red" trap)
+  # on every push to a PR branch.
   push:
-    paths:
-      - '**'
+    branches: [main]
   pull_request:
-    paths:
-      - '**'
 
 jobs:
   lint:


### PR DESCRIPTION
Scopes the `push` CI trigger to `main` only.

`push` fired on **every** branch (`paths: ['**']`, no branch filter), so each push to a PR branch spawned a redundant `push` run alongside the `pull_request` run. When a fix needed a re-run, only one of the twins got re-run and the PR stayed red (this bit #20 and #21). `pull_request` already covers PR branches; `push` on `main` still verifies post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
