### PR TITLE
Bump waldoctl pin to v0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.5.0",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.6.2",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
waldoctl v0.6.2 loosens its nicegui dependency to a named requirement, so app-side combo-SHA bumps no longer conflict with waldoctl's direct-URL pin (pip rejects differing direct-URL pins for the same package). This aligns parol6's waldoctl pin with the frontend's.

Pin-only change; no runtime code differs. Release intent: tag **v0.3.1** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7tEqGhaTqJV6ZxCXgMpFU