### PR TITLE
Unhomed motion gate, fast-path home, stop/estop/reset

### DIFF
--- a/parol6/ack_policy.py
+++ b/parol6/ack_policy.py
@@ -4,12 +4,13 @@ from parol6.protocol.wire import CmdType
 
 # System command types (always require ACK)
 SYSTEM_CMD_TYPES: set[CmdType] = {
-    CmdType.RESUME,
-    CmdType.HALT,
+    CmdType.RESET,
+    CmdType.ESTOP,
+    CmdType.STOP,
     CmdType.CONNECT_HARDWARE,
     CmdType.SIMULATOR,
     CmdType.SELECT_PROFILE,
-    CmdType.RESET,
+    CmdType.RESET_STATE,
     CmdType.WRITE_IO,
     CmdType.SET_TCP_OFFSET,
     CmdType.SET_SHAPES,

--- a/parol6/client/async_client.py
+++ b/parol6/client/async_client.py
@@ -660,6 +660,10 @@ class AsyncRobotClient(_RobotClientABC):
     ) -> int:
         """Home the robot to its home position.
 
+        Unhomed, this runs the full referencing sequence (each joint seeks
+        its limit switch, then moves to standby). Already homed, it returns
+        to standby with a normal planned, collision-checked joint move.
+
         Returns the command index (≥ 0) on success, -1 on failure.
 
         Category: Motion

--- a/parol6/client/async_client.py
+++ b/parol6/client/async_client.py
@@ -41,7 +41,7 @@ from ..protocol.wire import (
     IOResultStruct,
     JointSpeedsCmd,
     LoopStatsCmd,
-    HaltCmd,
+    EstopCmd,
     HomeCmd,
     JogJCmd,
     JogLCmd,
@@ -64,8 +64,9 @@ from ..protocol.wire import (
     ReachableCmd,
     ResetCmd,
     ResetLoopStatsCmd,
-    ResumeCmd,
+    ResetStateCmd,
     Response,
+    StopCmd,
     ResponseMsg,
     SelectProfileCmd,
     SelectToolCmd,
@@ -683,31 +684,48 @@ class AsyncRobotClient(_RobotClientABC):
                 raise TimeoutError(f"home() timed out after {timeout}s")
         return index
 
-    async def resume(self) -> int:
-        """Re-enable the robot controller, allowing motion commands.
+    async def stop(self) -> int:
+        """Stop all motion — cancel the active move and clear the queue.
+
+        The controller stays enabled and holding position; the next motion
+        command is accepted immediately.
 
         Category: Control
 
         Example:
-            rbt.resume()
+            rbt.stop()
 
         Returns:
             1 if acknowledged, 0 on failure.
         """
-        return await self._send(ResumeCmd())
+        return await self._send(StopCmd())
 
-    async def halt(self) -> int:
-        """Halt the robot — stop all motion and disable.
+    async def estop(self) -> int:
+        """Protective stop: stop all motion and latch the controller
+        disabled until ``reset()``.
 
         Category: Control
 
         Example:
-            rbt.halt()
+            rbt.estop()
 
         Returns:
             1 if acknowledged, 0 on failure.
         """
-        return await self._send(HaltCmd())
+        return await self._send(EstopCmd())
+
+    async def reset(self) -> int:
+        """Clear a latched protective stop, re-enabling motion.
+
+        Category: Control
+
+        Example:
+            rbt.reset()
+
+        Returns:
+            1 if acknowledged, 0 on failure.
+        """
+        return await self._send(ResetCmd())
 
     async def simulator(self, enabled: bool) -> int:
         """Enable or disable simulator mode.
@@ -768,7 +786,7 @@ class AsyncRobotClient(_RobotClientABC):
             raise ValueError("No port provided")
         return await self._send(ConnectHardwareCmd(port_str=port_str))
 
-    async def reset(self) -> int:
+    async def reset_state(self) -> int:
         """Reset controller state to initial values.
 
         Instantly resets positions to home, clears queues, resets tool/errors.
@@ -777,9 +795,9 @@ class AsyncRobotClient(_RobotClientABC):
         Category: Control
 
         Example:
-            rbt.reset()
+            rbt.reset_state()
         """
-        return await self._send(ResetCmd())
+        return await self._send(ResetStateCmd())
 
     # --------------- Status / Queries ---------------
     async def ping(self) -> PingResult | None:

--- a/parol6/client/dry_run_client.py
+++ b/parol6/client/dry_run_client.py
@@ -250,7 +250,10 @@ class DryRunRobotClient:
     def _dispatch(self, params: Any) -> DryRunResult | None:
         """Route a command struct through the trajectory planner."""
         if isinstance(params, HomeCmd):
-            return self._snap_to_angles(HOME_ANGLES_DEG)
+            if not self._planner.state.Homed_in[:6].all():
+                return self._snap_to_angles(HOME_ANGLES_DEG)
+            # Already referenced → fall through: the planner fast-paths HOME
+            # into a planned return move, so the preview renders the path.
         if isinstance(params, TeleportCmd):
             return self._snap_to_angles(params.angles)
         if isinstance(params, SelectToolCmd):

--- a/parol6/client/dry_run_client.py
+++ b/parol6/client/dry_run_client.py
@@ -167,6 +167,7 @@ class DryRunRobotClient:
         self,
         initial_joints_deg: list[float] | None = None,
         max_snapshot_points: int = 200,
+        initial_homed: bool = True,
     ) -> None:
         # Reset tool transform — process pool workers persist across
         # invocations, so a previous run's select_tool() leaves a stale
@@ -190,6 +191,10 @@ class DryRunRobotClient:
 
         self._planner = TrajectoryPlanner(diagnostic=True)
         self._planner.state.Position_in[:] = self._state.Position_in
+        # Mirror the live gate: seeded from an unhomed robot, planned moves
+        # are refused until the script homes (home()/teleport() establish
+        # references — see _snap_to_angles).
+        self._planner.state.Homed_in.fill(1 if initial_homed else 0)
 
         self._registry = CommandRegistry()
         self._q_rad_buf = np.zeros(6, dtype=np.float64)
@@ -230,11 +235,15 @@ class DryRunRobotClient:
         return results
 
     def _snap_to_angles(self, angles_deg: list[float]) -> DryRunResult:
-        """Snap to angles instantly (no trajectory) — used by Home and Teleport."""
+        """Snap to angles instantly (no trajectory) — used by Home and Teleport.
+
+        Both establish position references, so subsequent planned moves pass
+        the homed gate."""
         self._planner.flush()
         deg = np.asarray(angles_deg, dtype=np.float64)
         deg_to_steps(deg, self._state.Position_in)
         self._planner.state.Position_in[:] = self._state.Position_in
+        self._planner.state.Homed_in.fill(1)
         rad = np.radians(deg).reshape(1, -1)
         return _build_result(rad, duration=0.0)
 

--- a/parol6/client/sync_client.py
+++ b/parol6/client/sync_client.py
@@ -178,6 +178,10 @@ class RobotClient:
     def home(self, wait: bool = False, timeout: float = 60.0) -> int:
         """Home the robot to its home position.
 
+        Unhomed, this runs the full referencing sequence (each joint seeks
+        its limit switch, then moves to standby). Already homed, it returns
+        to standby with a normal planned, collision-checked joint move.
+
         Returns the command index (≥ 0) on success, -1 on failure.
 
         Args:

--- a/parol6/client/sync_client.py
+++ b/parol6/client/sync_client.py
@@ -112,7 +112,7 @@ class RobotClient:
     Can be used as a context manager to ensure proper cleanup:
 
         with RobotClient() as client:
-            client.resume()
+            client.home()
             ...
     """
 
@@ -198,21 +198,33 @@ class RobotClient:
         """Instantly set joint angles and optional tool positions (simulator only)."""
         return _run(self._inner.teleport(angles_deg, tool_positions=tool_positions))
 
-    def resume(self) -> int:
-        """Re-enable the robot controller, allowing motion commands.
+    def stop(self) -> int:
+        """Stop all motion — cancel the active move and clear the queue.
+
+        The controller stays enabled and holding position; the next motion
+        command is accepted immediately.
 
         Returns:
             1 if acknowledged, 0 on failure.
         """
-        return _run(self._inner.resume())
+        return _run(self._inner.stop())
 
-    def halt(self) -> int:
-        """Halt the robot — stop all motion and disable.
+    def estop(self) -> int:
+        """Protective stop: stop all motion and latch the controller
+        disabled until ``reset()``.
 
         Returns:
             1 if acknowledged, 0 on failure.
         """
-        return _run(self._inner.halt())
+        return _run(self._inner.estop())
+
+    def reset(self) -> int:
+        """Clear a latched protective stop, re-enabling motion.
+
+        Returns:
+            1 if acknowledged, 0 on failure.
+        """
+        return _run(self._inner.reset())
 
     def simulator(self, enabled: bool) -> int:
         """Enable or disable simulator mode."""
@@ -233,9 +245,9 @@ class RobotClient:
         """
         return _run(self._inner.connect_hardware(port_str))
 
-    def reset(self) -> int:
+    def reset_state(self) -> int:
         """Reset controller state to initial values."""
-        return _run(self._inner.reset())
+        return _run(self._inner.reset_state())
 
     # ---------- status / queries ----------
     def ping(self) -> PingResult | None:

--- a/parol6/commands/base.py
+++ b/parol6/commands/base.py
@@ -13,10 +13,26 @@ import numpy as np
 from parol6.config import TRACE
 from parol6.protocol.wire import CmdType, Command, CommandCode, QueryType
 from parol6.server.state import ControllerState
-from parol6.utils.error_catalog import RobotError, extract_robot_error
+from parol6.utils.error_catalog import RobotError, extract_robot_error, make_error
 from parol6.utils.error_codes import ErrorCode
+from parol6.utils.errors import TrajectoryPlanningError
 
 logger = logging.getLogger(__name__)
+
+
+def guard_homed(state: ControllerState) -> None:
+    """Refuse planned motion while the robot is not homed.
+
+    Reported joint positions are unreferenced until homing (the boot state is
+    all-zeros steps — outside J2/J3's limits), so building or collision-checking
+    a trajectory from them is meaningless. Called at the top of every planned
+    command's ``do_setup``, like ``guard_joint_path``. Jog/servo/home are
+    deliberately not gated: they don't plan a path from the reported pose, and
+    an unhomed arm may need to be jogged clear of an obstruction before homing.
+    """
+    for i in range(6):
+        if not state.Homed_in[i]:
+            raise TrajectoryPlanningError(make_error(ErrorCode.MOTN_NOT_HOMED))
 
 
 class ExecutionStatusCode(Enum):

--- a/parol6/commands/basic_commands.py
+++ b/parol6/commands/basic_commands.py
@@ -77,7 +77,8 @@ class HomeState(Enum):
 class HomeCommand(MotionCommand[HomeCmd]):
     """
     A non-blocking command that tells the robot to perform its internal homing sequence.
-    This version uses a state machine to allow re-homing even if the robot is already homed.
+    Reached only while the robot is unhomed — the planner routes HOME from an
+    already-referenced robot to a planned return move instead.
     """
 
     PARAMS_TYPE = HomeCmd

--- a/parol6/commands/cartesian_commands.py
+++ b/parol6/commands/cartesian_commands.py
@@ -38,6 +38,7 @@ from .base import (
     ExecutionStatusCode,
     MotionCommand,
     TrajectoryMoveCommandBase,
+    guard_homed,
 )
 
 logger = logging.getLogger(__name__)
@@ -293,6 +294,7 @@ class MoveLCommand(TrajectoryMoveCommandBase[MoveLCmd]):
 
     def do_setup(self, state: "ControllerState") -> None:
         """Set up the move - compute target pose and pre-compute trajectory."""
+        guard_homed(state)
         self.initial_pose = get_fkine_se3(state)
         self._compute_target_pose(state)
         self._precompute_trajectory(state)
@@ -408,6 +410,7 @@ class MoveLCommand(TrajectoryMoveCommandBase[MoveLCmd]):
         next_cmds: "list[TrajectoryMoveCommandBase]",
     ) -> int:
         """Build composite Cartesian trajectory with blend zones."""
+        guard_homed(state)
         if self.blend_radius <= 0 or not next_cmds:
             self.do_setup(state)
             return 0

--- a/parol6/commands/curved_commands.py
+++ b/parol6/commands/curved_commands.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, TypeVar
 import numpy as np
 
 from parol6.commands._collision_guard import guard_joint_path
-from parol6.commands.base import TrajectoryMoveCommandBase
+from parol6.commands.base import TrajectoryMoveCommandBase, guard_homed
 from parol6.config import INTERVAL_S, LIMITS, steps_to_rad
 from parol6.motion import CircularMotion, JointPath, SplineMotion, TrajectoryBuilder
 from parol6.protocol.wire import (
@@ -115,6 +115,7 @@ class BaseSmoothMotionCommand(TrajectoryMoveCommandBase[_MP]):
 
     def do_setup(self, state: "ControllerState") -> None:
         """Pre-compute trajectory from current position."""
+        guard_homed(state)
         self.log_debug("  -> Preparing %s...", self.name)
 
         current_pose = self.get_current_pose(state)

--- a/parol6/commands/joint_commands.py
+++ b/parol6/commands/joint_commands.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import parol6.PAROL6_ROBOT as PAROL6_ROBOT
 from parol6.commands._collision_guard import guard_joint_path
-from parol6.commands.base import TrajectoryMoveCommandBase
+from parol6.commands.base import TrajectoryMoveCommandBase, guard_homed
 from parol6.config import (
     INTERVAL_S,
     MAX_BLEND_LOOKAHEAD,
@@ -79,6 +79,7 @@ class JointMoveCommandBase(TrajectoryMoveCommandBase[_MP]):
 
     def do_setup(self, state: ControllerState) -> None:
         """Build trajectory from current position to target using unified motion pipeline."""
+        guard_homed(state)
         steps_to_rad(state.Position_in, self._q_rad_buf)
         target_rad = self._get_target_rad(state, self._q_rad_buf)
         current_rad = self._q_rad_buf
@@ -116,6 +117,7 @@ class JointMoveCommandBase(TrajectoryMoveCommandBase[_MP]):
         next_cmds: "list[TrajectoryMoveCommandBase]",
     ) -> int:
         """Build composite joint-space trajectory with blend zones."""
+        guard_homed(state)
         if self.blend_radius <= 0 or not next_cmds:
             self.do_setup(state)
             return 0

--- a/parol6/commands/system_commands.py
+++ b/parol6/commands/system_commands.py
@@ -16,11 +16,12 @@ from parol6.config import save_com_port
 from parol6.protocol.wire import (
     CmdType,
     ConnectHardwareCmd,
-    HaltCmd,
-    ResumeCmd,
+    EstopCmd,
+    ResetCmd,
     SelectProfileCmd,
     SetTcpOffsetCmd,
     SimulatorCmd,
+    StopCmd,
     WriteIOCmd,
 )
 from parol6.protocol.wire import CommandCode
@@ -34,16 +35,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@register_command(CmdType.RESUME)
-class ResumeCommand(SystemCommand[ResumeCmd]):
-    """Re-enable the robot controller, allowing motion commands."""
+@register_command(CmdType.RESET)
+class ResetCommand(SystemCommand[ResetCmd]):
+    """Clear a latched protective stop, re-enabling motion commands."""
 
-    PARAMS_TYPE = ResumeCmd
+    PARAMS_TYPE = ResetCmd
 
     __slots__ = ()
 
     def execute_step(self, state: ControllerState) -> ExecutionStatusCode:
-        logger.info("RESUME command executed")
+        logger.info("RESET command executed")
         state.enabled = True
         state.disabled_reason = ""
         state.Command_out = CommandCode.ENABLE
@@ -52,20 +53,45 @@ class ResumeCommand(SystemCommand[ResumeCmd]):
         return ExecutionStatusCode.COMPLETED
 
 
-@register_command(CmdType.HALT)
-class HaltCommand(SystemCommand[HaltCmd]):
-    """Halt the robot — stop all motion and disable."""
+@register_command(CmdType.ESTOP)
+class EstopCommand(SystemCommand[EstopCmd]):
+    """Protective stop: stop all motion and latch the controller disabled
+    until RESET.
 
-    PARAMS_TYPE = HaltCmd
+    Motors stay energized (zero speed, holding position) — PAROL6 steppers
+    have no brakes, so de-energizing would let the arm sag. The protective
+    stop is the software latch, not motor power.
+    """
+
+    PARAMS_TYPE = EstopCmd
 
     __slots__ = ()
 
     def execute_step(self, state: ControllerState) -> ExecutionStatusCode:
-        logger.info("HALT command executed")
+        logger.info("ESTOP command executed")
         state.Speed_out.fill(0)
         state.enabled = False
-        state.disabled_reason = "User requested halt"
-        state.Command_out = CommandCode.DISABLE
+        state.disabled_reason = "Protective stop (estop)"
+        state.Command_out = CommandCode.IDLE
+
+        self.finish()
+        return ExecutionStatusCode.COMPLETED
+
+
+@register_command(CmdType.STOP)
+class StopCommand(SystemCommand[StopCmd]):
+    """Stop all motion — the controller stays enabled and accepts the next
+    command immediately. The motion pipeline (active trajectory + queue) is
+    canceled controller-side."""
+
+    PARAMS_TYPE = StopCmd
+
+    __slots__ = ()
+
+    def execute_step(self, state: ControllerState) -> ExecutionStatusCode:
+        logger.info("STOP command executed")
+        state.Speed_out.fill(0)
+        state.Command_out = CommandCode.IDLE
 
         self.finish()
         return ExecutionStatusCode.COMPLETED

--- a/parol6/commands/utility_commands.py
+++ b/parol6/commands/utility_commands.py
@@ -15,8 +15,8 @@ from parol6.protocol.wire import (
     CheckpointCmd,
     CmdType,
     DelayCmd,
-    ResetCmd,
     ResetLoopStatsCmd,
+    ResetStateCmd,
 )
 from parol6.protocol.wire import CommandCode
 from parol6.server.command_registry import register_command
@@ -52,13 +52,13 @@ class DelayCommand(CommandBase[DelayCmd]):
         return ExecutionStatusCode.EXECUTING
 
 
-@register_command(CmdType.RESET)
-class ResetCommand(SystemCommand[ResetCmd]):
+@register_command(CmdType.RESET_STATE)
+class ResetStateCommand(SystemCommand[ResetStateCmd]):
     """
     Instantly reset controller state to initial values.
     """
 
-    PARAMS_TYPE = ResetCmd
+    PARAMS_TYPE = ResetStateCmd
 
     __slots__ = ()
 

--- a/parol6/config.py
+++ b/parol6/config.py
@@ -201,6 +201,10 @@ _joint_ratio = PAROL6_ROBOT.joint.ratio
 STANDBY_ANGLES_DEG: list[float] = list(PAROL6_ROBOT.joint.standby_deg)
 HOME_ANGLES_DEG: list[float] = STANDBY_ANGLES_DEG
 
+# Velocity fraction for the fast-path home return (an already-referenced
+# robot returns to standby with a planned move instead of the switch-seek).
+HOME_RETURN_SPEED_FRAC: float = 0.5
+
 
 # JIT helper for rad_to_steps (needs wrapper because of thread-local scratch buffer)
 @njit(cache=True)

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -9,7 +9,7 @@ This module contains all protocol definitions:
 Wire format uses msgpack arrays with integer type codes:
 - OK:       MsgType.OK (just the integer)
 - ERROR:    [MsgType.ERROR, message]
-- STATUS:   [MsgType.STATUS, pose, angles, speeds, io, action_current, action_state, joint_en, cart_en_wrf, cart_en_trf, executing_index, completed_index, last_checkpoint, error, queued_segments, queued_duration, action_params, tool_status, tcp_speed, simulator_active, collision_active, collision_pairs, scene_epoch, accepted_index]
+- STATUS:   [MsgType.STATUS, pose, angles, speeds, io, action_current, action_state, joint_en, cart_en_wrf, cart_en_trf, executing_index, completed_index, last_checkpoint, error, queued_segments, queued_duration, action_params, tool_status, tcp_speed, simulator_active, collision_active, collision_pairs, scene_epoch, accepted_index, homed]
 - RESPONSE: [MsgType.RESPONSE, query_type, value]
 - COMMAND:  [CmdType.XXX, ...params]
 """
@@ -1337,6 +1337,7 @@ def pack_status(
     collision_pairs: tuple[tuple[str, str], ...] = (),
     scene_epoch: int = 0,
     accepted_index: int = -1,
+    homed: bool = True,
 ) -> bytes:
     """Pack a status broadcast message.
 
@@ -1380,6 +1381,7 @@ def pack_status(
             collision_pairs,
             scene_epoch,
             accepted_index,
+            homed,
         ),
         option=ormsgpack.OPT_SERIALIZE_NUMPY,
     )
@@ -1424,6 +1426,9 @@ class StatusBuffer:
     # the field. Lets waiters order a standing error against their own
     # command's acceptance (acceptance clears stale errors server-side).
     accepted_index: int = -1
+    # All joints homed. True from producers that predate the field (permissive:
+    # old servers gate nothing, so claiming unhomed would be a false alarm).
+    homed: bool = True
     # Built once in __post_init__, aliasing the two enable arrays the decoder
     # mutates in place.
     cart_en: dict[str, np.ndarray] = field(init=False, repr=False, compare=False)
@@ -1469,6 +1474,7 @@ class StatusBuffer:
             collision_pairs=list(self.collision_pairs),
             scene_epoch=self.scene_epoch,
             accepted_index=self.accepted_index,
+            homed=self.homed,
         )
 
 
@@ -1481,7 +1487,7 @@ def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:
                      error, queued_segments, queued_duration, action_params,
                      tool_status_tuple, tcp_speed, simulator_active,
                      collision_active, collision_pairs, scene_epoch,
-                     accepted_index]
+                     accepted_index, homed]
 
     Args:
         data: Raw msgpack bytes
@@ -1552,6 +1558,7 @@ def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:
         if len(msg) > 22:
             buf.scene_epoch = int(msg[22])
         buf.accepted_index = int(msg[23]) if len(msg) > 23 else -1
+        buf.homed = bool(msg[24]) if len(msg) > 24 else True
 
         return True
     except Exception as e:

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -117,13 +117,14 @@ class CmdType(IntEnum):
     TCP_OFFSET = auto()
 
     # System commands (execute regardless of enable state)
-    RESUME = auto()
-    HALT = auto()
+    RESET = auto()
+    ESTOP = auto()
+    STOP = auto()
     WRITE_IO = auto()
     CONNECT_HARDWARE = auto()
     SIMULATOR = auto()
     SELECT_PROFILE = auto()
-    RESET = auto()
+    RESET_STATE = auto()
     RESET_LOOP_STATS = auto()
 
     # Motion commands — queued, pre-computed trajectory
@@ -504,26 +505,34 @@ class HomeCmd(
     pass
 
 
-class ResumeCmd(
-    msgspec.Struct, tag=int(CmdType.RESUME), array_like=True, frozen=True, gc=False
-):
-    """RESUME: [CmdType.RESUME] — re-enable the controller."""
-
-    pass
-
-
-class HaltCmd(
-    msgspec.Struct, tag=int(CmdType.HALT), array_like=True, frozen=True, gc=False
-):
-    """HALT: [CmdType.HALT] — stop all motion and disable."""
-
-    pass
-
-
 class ResetCmd(
     msgspec.Struct, tag=int(CmdType.RESET), array_like=True, frozen=True, gc=False
 ):
-    """RESET: [CmdType.RESET]"""
+    """RESET: [CmdType.RESET] — clear a latched protective stop, re-enabling motion."""
+
+    pass
+
+
+class EstopCmd(
+    msgspec.Struct, tag=int(CmdType.ESTOP), array_like=True, frozen=True, gc=False
+):
+    """ESTOP: [CmdType.ESTOP] — protective stop: stop all motion and latch disabled until RESET."""
+
+    pass
+
+
+class StopCmd(
+    msgspec.Struct, tag=int(CmdType.STOP), array_like=True, frozen=True, gc=False
+):
+    """STOP: [CmdType.STOP] — cancel active motion and queue; controller stays enabled."""
+
+    pass
+
+
+class ResetStateCmd(
+    msgspec.Struct, tag=int(CmdType.RESET_STATE), array_like=True, frozen=True, gc=False
+):
+    """RESET_STATE: [CmdType.RESET_STATE] — reset controller state (shapes, tool, errors)."""
 
     pass
 
@@ -1798,9 +1807,10 @@ __all__ = [
     "JogJCmd",
     "JogLCmd",
     # Command structs — system/control
-    "ResumeCmd",
-    "HaltCmd",
     "ResetCmd",
+    "EstopCmd",
+    "StopCmd",
+    "ResetStateCmd",
     "ResetLoopStatsCmd",
     "WriteIOCmd",
     "ConnectHardwareCmd",

--- a/parol6/robot.py
+++ b/parol6/robot.py
@@ -988,4 +988,8 @@ class Robot(_RobotABC):
 
     def create_dry_run_client(self, **kwargs: Any) -> DryRunClient | None:
         initial_joints_deg: list[float] | None = kwargs.get("initial_joints_deg")
-        return DryRunRobotClient(initial_joints_deg=initial_joints_deg)  # ty: ignore[invalid-return-type]
+        initial_homed: bool = bool(kwargs.get("initial_homed", True))
+        return DryRunRobotClient(  # ty: ignore[invalid-return-type]
+            initial_joints_deg=initial_joints_deg,
+            initial_homed=initial_homed,
+        )

--- a/parol6/server/controller.py
+++ b/parol6/server/controller.py
@@ -745,16 +745,25 @@ class Controller:
         state.clear_collision()
 
         cmd_index = self._assign_command_index(state)
-        # Only sync Position_in when segment player is idle — if segments are
-        # active/queued (e.g. homing), the planner's internal tracking is correct
-        # and Position_in may reflect a mid-motion position.
+        # Only sync Position_in / homed when segment player is idle — if
+        # segments are active/queued (e.g. homing), the planner's internal
+        # tracking is correct: Position_in may reflect a mid-motion position
+        # and the planner has already predicted a queued HOME's homed flags.
         segment_idle = not self._segment_player.active
         pos_snapshot = state.Position_in.copy() if segment_idle else None
+        homed_snapshot: bool | None = None
+        if segment_idle:
+            homed_snapshot = True
+            for i in range(6):
+                if not state.Homed_in[i]:
+                    homed_snapshot = False
+                    break
         self._planner.submit(
             PlanCommand(
                 command_index=cmd_index,
                 params=command.p,
                 position_in=pos_snapshot,
+                homed=homed_snapshot,
             )
         )
         if cmd_type and self._ack_policy.requires_ack(cmd_type):

--- a/parol6/server/controller.py
+++ b/parol6/server/controller.py
@@ -23,8 +23,12 @@ from parol6.commands.base import (
     SystemCommand,
 )
 from parol6.commands.shape_commands import SetShapesCommand
-from parol6.commands.system_commands import SelectProfileCommand
-from parol6.commands.utility_commands import ResetCommand
+from parol6.commands.system_commands import (
+    EstopCommand,
+    SelectProfileCommand,
+    StopCommand,
+)
+from parol6.commands.utility_commands import ResetStateCommand
 from parol6.server.command_executor import CommandExecutor, QueueFullError
 from parol6.server.motion_planner import MotionPlanner, PlanCommand
 from parol6.server.segment_player import SegmentPlayer
@@ -798,10 +802,23 @@ class Controller:
             command.setup(state)
             code = command.tick(state)
 
-            # Reset: cancel motion pipeline so stale segments don't play.
+            # Stop/estop: cancel the motion pipeline, or the segment player
+            # keeps playing the active trajectory (rewriting Command_out and
+            # fresh speeds every tick) and the "stopped" robot drives on.
+            if isinstance(command, (StopCommand, EstopCommand)):
+                reason = (
+                    "Protective stop"
+                    if isinstance(command, EstopCommand)
+                    else "User requested stop"
+                )
+                self._segment_player.cancel(state)
+                self._executor.cancel_active_command(reason)
+                self._executor.clear_queue(reason)
+
+            # Reset-state: cancel motion pipeline so stale segments don't play.
             # Also sync the (now-cleared) tool state to the planner subprocess
             # so its PAROL6_ROBOT singleton matches the controller's.
-            if isinstance(command, ResetCommand):
+            if isinstance(command, ResetStateCommand):
                 self._segment_player.cancel(state)
                 self._executor.cancel_active_command("Reset")
                 self._executor.clear_queue("Reset")

--- a/parol6/server/motion_planner.py
+++ b/parol6/server/motion_planner.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from parol6.protocol.wire import (
     HomeCmd,
+    MoveJCmd,
     SelectToolCmd,
     SetShapesCmd,
     SetTcpOffsetCmd,
@@ -201,7 +202,11 @@ class TrajectoryPlanner:
     def __init__(self, diagnostic: bool = False) -> None:
         import parol6.PAROL6_ROBOT as PAROL6_ROBOT  # noqa: N811
         from parol6.commands.base import TrajectoryMoveCommandBase
-        from parol6.config import MAX_BLEND_LOOKAHEAD, deg_to_steps
+        from parol6.config import (
+            HOME_RETURN_SPEED_FRAC,
+            MAX_BLEND_LOOKAHEAD,
+            deg_to_steps,
+        )
         from parol6.server.command_registry import CommandRegistry
 
         self.state = PlannerState()
@@ -221,10 +226,18 @@ class TrajectoryPlanner:
         self._home_steps = np.zeros(6, dtype=np.int32)
         _home_deg = np.array(PAROL6_ROBOT.joint.standby_deg, dtype=np.float64)
         deg_to_steps(_home_deg, self._home_steps)
+        self._home_deg: list[float] = [float(v) for v in _home_deg]
+        self._home_return_speed = HOME_RETURN_SPEED_FRAC
 
     def process(self, params: object, command_index: int = 0) -> list[Segment]:
         """Plan a single command. Returns list of resulting segments."""
         self._output.clear()
+
+        # Fast-path home: an already-referenced robot returns to the standby
+        # pose with a normal planned (collision-checked) joint move instead
+        # of re-running the firmware switch-seek.
+        if isinstance(params, HomeCmd) and bool(self.state.Homed_in[:6].all()):
+            params = MoveJCmd(angles=self._home_deg, speed=self._home_return_speed)
 
         cmd_class = self._registry.get_command_for_struct(type(params))
         if cmd_class is not None and issubclass(cmd_class, self._trajectory_base):

--- a/parol6/server/motion_planner.py
+++ b/parol6/server/motion_planner.py
@@ -94,6 +94,7 @@ class PlanCommand:
     position_in: np.ndarray | None = (
         None  # current Position_in (None = use planner internal)
     )
+    homed: bool | None = None  # all joints homed (None = use planner internal)
 
 
 @dataclass
@@ -151,6 +152,11 @@ class PlannerState:
     """
 
     Position_in: np.ndarray = field(default_factory=lambda: np.zeros(6, dtype=np.int32))
+    # Same shape/dtype as ControllerState.Homed_in so guard_homed reads both.
+    # Defaults to homed: the planner is fed real flags at dispatch (PlanCommand
+    # snapshot) and predicts a queued HOME; a pessimistic default would refuse
+    # dry runs that were seeded from an already-homed robot.
+    Homed_in: np.ndarray = field(default_factory=lambda: np.ones(8, dtype=np.uint8))
     motion_profile: str = "TOPPRA"
     current_tool: str = "NONE"
     current_tool_variant: str = ""
@@ -482,6 +488,7 @@ class TrajectoryPlanner:
             )
         elif isinstance(params, HomeCmd):
             self.state.Position_in[:] = self._home_steps
+            self.state.Homed_in.fill(1)
         elif isinstance(params, SetShapesCmd):
             # Only reachable via the DRY-RUN planner: a script's set_shapes()
             # must shape its preview world. The live path routes SET_SHAPES as
@@ -515,6 +522,8 @@ class PlannerWorker:
         """Route a PlanCommand through the planner and emit segments."""
         if msg.position_in is not None:
             self._planner.state.Position_in[:] = msg.position_in
+        if msg.homed is not None:
+            self._planner.state.Homed_in.fill(1 if msg.homed else 0)
 
         segments = self._planner.process(msg.params, msg.command_index)
         for seg in segments:

--- a/parol6/server/state.py
+++ b/parol6/server/state.py
@@ -318,7 +318,7 @@ class ControllerState:
         """
         Reset robot state to initial values without losing connection state.
 
-        Preserves: ser, ip, port, start_time
+        Preserves: ser, ip, port, start_time, next_command_index
         Resets: positions, speeds, I/O, queues, tool, errors, etc.
         """
         # Safety and control flags
@@ -360,8 +360,10 @@ class ControllerState:
         self.action_next = ""
         self.queue_nonstreamable.clear()
 
-        # Queue progress tracking
-        self.next_command_index = 0
+        # Queue progress tracking. next_command_index is deliberately NOT
+        # reset: indices must stay monotonic across reset so a stale
+        # pre-reset status frame (its completed_index is a high-water mark)
+        # can never satisfy a wait on a post-reset command.
         self.executing_command_index = -1
         self.completed_command_index = -1
         self.last_checkpoint = ""

--- a/parol6/server/status_cache.py
+++ b/parol6/server/status_cache.py
@@ -164,6 +164,9 @@ class StatusCache:
         # Error tracking field
         self._error: RobotError | None = None
 
+        # All-joints-homed tracking field
+        self._homed: bool = False
+
         # Self-collision viz tracking
         self._collision_active: bool = False
         self._collision_pairs: tuple[tuple[str, str], ...] = ()
@@ -501,6 +504,16 @@ class StatusCache:
         if error_changed:
             self._error = state.error
 
+        # Scalar loop keeps the 100Hz path allocation-free (no slice/temporary).
+        homed = True
+        for i in range(6):
+            if not state.Homed_in[i]:
+                homed = False
+                break
+        homed_changed = self._homed != homed
+        if homed_changed:
+            self._homed = homed
+
         collision_changed = (
             self._collision_active != state.collision_active
             or self._collision_pairs != state.collision_pairs
@@ -528,6 +541,7 @@ class StatusCache:
             or action_changed
             or queue_changed
             or error_changed
+            or homed_changed
             or collision_changed
             or depth_changed
         ):
@@ -562,6 +576,7 @@ class StatusCache:
                 collision_pairs=self._collision_pairs,
                 scene_epoch=self._last_shapes_version,
                 accepted_index=self._accepted_index,
+                homed=self._homed,
             )
             self._binary_dirty = False
         return self._binary_cache

--- a/parol6/utils/error_catalog.py
+++ b/parol6/utils/error_catalog.py
@@ -154,13 +154,13 @@ _CATALOG: dict[int, _ErrorTemplate] = {
         title="Controller disabled",
         cause="Motion command sent while controller is disabled. {detail}",
         effect="Command rejected.",
-        remedy="Call resume() to re-enable the controller.",
+        remedy="Call reset() to re-enable the controller.",
     ),
     ErrorCode.SYS_ESTOP_ACTIVE: _ErrorTemplate(
         title="E-stop active",
         cause="Emergency stop is currently engaged.",
-        effect="All motion halted. Queue cleared.",
-        remedy="Release the E-stop button and call resume().",
+        effect="All motion stopped. Queue cleared.",
+        remedy="Release the E-stop button and call reset().",
     ),
     ErrorCode.SYS_PORT_SAVE_FAILED: _ErrorTemplate(
         title="Serial port save failed",

--- a/parol6/utils/error_catalog.py
+++ b/parol6/utils/error_catalog.py
@@ -115,6 +115,15 @@ _CATALOG: dict[int, _ErrorTemplate] = {
         effect="Command aborted. Robot stopped.",
         remedy="Check robot state. May need to re-home.",
     ),
+    ErrorCode.MOTN_NOT_HOMED: _ErrorTemplate(
+        title="Robot not homed",
+        cause=(
+            "Planned motion requested while the robot is not homed — "
+            "reported joint positions are unreferenced until homing."
+        ),
+        effect="Motion command rejected before dispatch.",
+        remedy="Run home() first. Jogging remains available.",
+    ),
     # -- Communication --
     ErrorCode.COMM_QUEUE_FULL: _ErrorTemplate(
         title="Command queue full",

--- a/parol6/utils/error_codes.py
+++ b/parol6/utils/error_codes.py
@@ -26,6 +26,7 @@ class ErrorCode(IntEnum):
     MOTN_GRIPPER_UNKNOWN = 32
     MOTN_SETUP_FAILED = 33
     MOTN_TICK_FAILED = 34
+    MOTN_NOT_HOMED = 35
 
     # Communication / protocol
     COMM_QUEUE_FULL = 40

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.6.2",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.7.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,10 @@ def client(ports: TestPorts):
     return RobotClient(
         host=ports.server_ip,
         port=ports.server_port,
+        # Overloaded CI runners (macOS especially) can hold an ack past the
+        # default 2s window; the retry then lapses too and system commands
+        # spuriously report failure.
+        timeout=5.0,
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ def clean_state(server_proc, client):
     Sets LINEAR motion profile for faster test execution.
     Depends on server_proc to ensure server is ready before resetting.
     """
-    client.reset()
+    client.reset_state()
     client.select_profile("LINEAR")
     idx = client.home()
     assert idx >= 0, "Home command failed to send"

--- a/tests/integration/test_home_fastpath.py
+++ b/tests/integration/test_home_fastpath.py
@@ -1,0 +1,50 @@
+"""home() on an already-referenced robot is a planned return move.
+
+The firmware switch-seek establishes references and runs only while the
+robot is unhomed; once referenced, HOME plans a normal collision-checked
+joint move back to the standby pose instead of re-running the sequence.
+Proven by a keep-out enveloping the standby pose: the planned return is
+refused, where the unchecked firmware sequence would drive through it.
+"""
+
+import numpy as np
+import pytest
+
+from parol6 import MotionError, RobotClient
+from waldoctl import Box
+
+pytestmark = pytest.mark.integration
+
+
+def test_home_returns_via_planned_move_when_referenced(
+    client: RobotClient, server_proc
+):
+    import parol6.PAROL6_ROBOT as PAROL6_ROBOT
+
+    standby = list(PAROL6_ROBOT.joint.standby_deg)
+    away = [45.0, -60.0, 150.0, 0.0, 30.0, 90.0]
+    assert client.move_j(away, duration=2.0, wait=True) >= 0
+
+    p = PAROL6_ROBOT.robot.fkine(np.radians(standby))[:3, 3]
+    box = Box(
+        name="home-blocker",
+        x=0.25,
+        y=0.25,
+        z=0.25,
+        pose=(float(p[0]), float(p[1]), float(p[2]), 0, 0, 0),
+    )
+    try:
+        assert client.set_shapes([box]) == 1
+        with pytest.raises(MotionError, match="home-blocker"):
+            client.home(wait=True, timeout=30.0)
+    finally:
+        assert client.set_shapes([]) == 1
+
+    # Cleared: the fast-path return completes and lands on the standby pose.
+    assert client.home(wait=True, timeout=30.0) >= 0
+    angles = client.angles()
+    assert angles is not None
+    assert np.allclose(angles, standby, atol=0.5)
+
+    # Degenerate re-home (already at standby) completes as a no-op move.
+    assert client.home(wait=True, timeout=10.0) >= 0

--- a/tests/integration/test_movecart_accuracy.py
+++ b/tests/integration/test_movecart_accuracy.py
@@ -14,7 +14,7 @@ class TestMoveLAccuracy:
     def test_move_l_from_home(self, client, server_proc):
         """Test move_l accuracy starting from home position."""
         # Ensure controller is enabled before motion
-        assert client.resume() > 0
+        assert client.reset() > 0
         # Home the robot first
         assert client.home() >= 0
         assert client.wait_motion(timeout=15.0)
@@ -65,7 +65,7 @@ class TestMoveLAccuracy:
     def test_move_l_multiple_targets(self, client, server_proc):
         """Test move_l accuracy with multiple sequential targets."""
         # Ensure controller is enabled before motion
-        assert client.resume() > 0
+        assert client.reset() > 0
         # Home first
         assert client.home() >= 0
         assert client.wait_motion(timeout=15.0)

--- a/tests/integration/test_profile_commands.py
+++ b/tests/integration/test_profile_commands.py
@@ -17,7 +17,7 @@ class TestProfileCommands:
 
     def test_profile_returns_default(self, client, server_proc):
         """Test GETPROFILE returns default profile (TOPPRA) after reset."""
-        client.reset()
+        client.reset_state()
         result = client.profile()
         assert result is not None
         assert result == "TOPPRA"

--- a/tests/integration/test_profile_commands.py
+++ b/tests/integration/test_profile_commands.py
@@ -43,11 +43,17 @@ class TestProfileMotionBehavior:
 
     def test_joint_move_reaches_target_all_profiles(self, client, server_proc):
         """Test that joint moves reach target position with all profiles."""
+        import parol6.PAROL6_ROBOT as PAROL6_ROBOT
+
         target_angles = [10, -50, 190, 5, 10, 15]
+        standby = [float(v) for v in PAROL6_ROBOT.joint.standby_deg]
 
         for p in ["LINEAR", "QUINTIC", "TRAPEZOID", "RUCKIG", "TOPPRA"]:
-            # Reset to home first
-            client.home(wait=True)
+            # Teleport to the standby pose: each profile starts from the same
+            # spot without paying for five planned home moves (home() on a
+            # referenced robot is a real planned move now, not a firmware
+            # re-home — slow CI runners blew the per-test timeout on it).
+            assert client.teleport(standby) == 1
 
             # Set profile and execute move
             assert client.select_profile(p) > 0
@@ -84,11 +90,16 @@ class TestProfileMotionBehavior:
             start_pose[5],
         ]
 
+        import parol6.PAROL6_ROBOT as PAROL6_ROBOT
+
+        standby = [float(v) for v in PAROL6_ROBOT.joint.standby_deg]
+
         # All profiles should work for Cartesian moves
         # RUCKIG falls back to TOPPRA automatically
         for p in ["LINEAR", "QUINTIC", "TRAPEZOID", "RUCKIG", "TOPPRA"]:
-            # Reset to home first
-            client.home(wait=True)
+            # Teleport, don't drive: five planned home moves blow the
+            # per-test timeout on slow runners.
+            assert client.teleport(standby) == 1
 
             # Set profile and execute move
             assert client.select_profile(p) > 0

--- a/tests/integration/test_reset_semantics.py
+++ b/tests/integration/test_reset_semantics.py
@@ -29,7 +29,7 @@ def test_wait_command_ignores_pre_reset_frames(client: RobotClient, server_proc)
     # — the stale high-water mark that used to alias recycled indices.
     assert client.wait_status(_capture, timeout=5.0)
 
-    client.reset()
+    client.reset_state()
     idx = client.delay(1.0)
     assert idx > seen["completed"], (
         f"index {idx} recycled across reset (pre-reset completed_index was "

--- a/tests/integration/test_reset_semantics.py
+++ b/tests/integration/test_reset_semantics.py
@@ -1,0 +1,44 @@
+"""Command indices stay monotonic across RESET.
+
+Pre-fix, ``state.reset()`` recycled ``next_command_index`` to 0 while status
+frames generated before the reset — cached client-side and in flight on the
+multicast group — still carried the old ``completed_index`` high-water mark.
+Any ``wait_command`` on a recycled index was satisfied instantly by such a
+frame, reporting success for a command that hadn't run (the autouse
+fixture's post-reset ``home(wait=...)`` survived only by frame timing).
+Indices now keep counting across reset, so no stale frame can alias a
+post-reset command.
+"""
+
+import pytest
+
+from parol6 import RobotClient
+from waldoctl import StatusBuffer
+
+pytestmark = pytest.mark.integration
+
+
+def test_wait_command_ignores_pre_reset_frames(client: RobotClient, server_proc):
+    seen: dict[str, int] = {}
+
+    def _capture(s: StatusBuffer) -> bool:
+        seen["completed"] = s.completed_index
+        return s.completed_index >= 0
+
+    # Ensure the client's cached frame carries the fixture home's completion
+    # — the stale high-water mark that used to alias recycled indices.
+    assert client.wait_status(_capture, timeout=5.0)
+
+    client.reset()
+    idx = client.delay(1.0)
+    assert idx > seen["completed"], (
+        f"index {idx} recycled across reset (pre-reset completed_index was "
+        f"{seen['completed']}) — stale frames can alias it"
+    )
+
+    # The delay is still running: only a stale pre-reset frame could satisfy
+    # this wait early.
+    assert not client.wait_command(idx, timeout=0.2), (
+        "wait_command satisfied by a stale pre-reset status frame"
+    )
+    assert client.wait_command(idx, timeout=5.0), "delay never completed"

--- a/tests/integration/test_shapes_e2e.py
+++ b/tests/integration/test_shapes_e2e.py
@@ -112,7 +112,7 @@ def test_set_shapes_mid_flight_halts_streaming_move(client: RobotClient, server_
         time.sleep(0.3)
         assert abs(_j1(client) - j1_stop) < 0.5, "arm kept moving after the halt"
     finally:
-        client.reset()
+        client.reset_state()
         assert client.set_shapes([]) == 1
 
 
@@ -150,7 +150,7 @@ def test_set_shapes_mid_flight_rejects_queued_move_at_activation(
         time.sleep(0.3)
         assert abs(_j1(client) - 60.0) < 2.0, "second move streamed despite the wall"
     finally:
-        client.reset()
+        client.reset_state()
         assert client.set_shapes([]) == 1
 
 

--- a/tests/integration/test_stop_semantics.py
+++ b/tests/integration/test_stop_semantics.py
@@ -1,0 +1,91 @@
+"""STOP cancels in-flight motion without latching; ESTOP latches until RESET.
+
+Pre-fix (as HALT), the segment player kept playing the active trajectory —
+each tick rewrote Command_out and fresh speeds, clobbering the stop before
+transmission — so a "stopped" robot drove on to its target, and queued
+motion survived to play out later. And the only stop primitive latched the
+controller disabled, so a plain "just stop" left the robot rejecting every
+subsequent command.
+"""
+
+import time
+
+import numpy as np
+import pytest
+
+from parol6 import MotionError, RobotClient
+
+pytestmark = pytest.mark.integration
+
+
+def _wait_until_moving(client: RobotClient, start: list[float]) -> None:
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        a = client.angles()
+        if a is not None and not np.allclose(a, start, atol=0.2):
+            return
+        time.sleep(0.02)
+    pytest.fail("move never started")
+
+
+def _assert_frozen(client: RobotClient, target: list[float]) -> list[float]:
+    # Fixed observation window: "stays frozen" has no condition to poll for.
+    time.sleep(0.2)
+    frozen = client.angles()
+    assert frozen is not None
+    time.sleep(0.5)
+    after = client.angles()
+    assert after is not None
+    assert np.allclose(after, frozen, atol=0.05), (
+        f"robot kept moving after stop: {frozen} -> {after}"
+    )
+    assert not np.allclose(after, target, atol=0.5), (
+        "trajectory played to completion despite stop"
+    )
+    return after
+
+
+def test_stop_cancels_motion_and_stays_enabled(client: RobotClient, server_proc):
+    away = [45.0, -60.0, 150.0, 0.0, 30.0, 90.0]
+    queued = [90.0, -45.0, 120.0, 10.0, 20.0, 90.0]
+    start = client.angles()
+    assert start is not None
+
+    assert client.move_j(away, duration=4.0, wait=False) >= 0
+    assert client.move_j(queued, duration=2.0, wait=False) >= 0
+    _wait_until_moving(client, start)
+
+    assert client.stop() == 1
+    after = _assert_frozen(client, away)
+
+    # No latch: the very next command is accepted, and the canceled/queued
+    # motion never resurfaces.
+    assert client.home(wait=True, timeout=30.0) >= 0
+    final = client.angles()
+    assert final is not None
+    assert not np.allclose(final, after, atol=0.05)
+
+
+def test_estop_latches_until_reset(client: RobotClient, server_proc):
+    away = [45.0, -60.0, 150.0, 0.0, 30.0, 90.0]
+    start = client.angles()
+    assert start is not None
+
+    assert client.move_j(away, duration=4.0, wait=False) >= 0
+    _wait_until_moving(client, start)
+
+    assert client.estop() == 1
+    after = _assert_frozen(client, away)
+
+    with pytest.raises(MotionError, match="disabled"):
+        client.home()
+
+    assert client.reset() == 1
+    # Reset clears the latch but never resurrects canceled motion.
+    time.sleep(0.5)
+    resumed = client.angles()
+    assert resumed is not None
+    assert np.allclose(resumed, after, atol=0.05), (
+        "canceled motion resurfaced after reset"
+    )
+    assert client.home(wait=True, timeout=30.0) >= 0

--- a/tests/integration/test_streaming_cartesian_accuracy.py
+++ b/tests/integration/test_streaming_cartesian_accuracy.py
@@ -48,7 +48,7 @@ class TestServoCartesianAccuracy:
 
         Tests the servo Cartesian path (replaces old stream_on + move_cartesian).
         """
-        assert client.resume() > 0
+        assert client.reset() > 0
         assert client.home() >= 0
         assert client.wait_motion(timeout=15.0)
 
@@ -81,7 +81,7 @@ class TestServoCartesianAccuracy:
         Simulates TCP dragging behavior where multiple servo_l commands
         are sent in sequence.
         """
-        assert client.resume() > 0
+        assert client.reset() > 0
         assert client.home() >= 0
         assert client.wait_motion(timeout=15.0)
 

--- a/tests/integration/test_udp_smoke.py
+++ b/tests/integration/test_udp_smoke.py
@@ -195,18 +195,19 @@ class TestErrorHandling:
         client = RobotClient(ports.server_ip, ports.server_port)
         assert client.ping() is not None
 
-    def test_halted_motion_raises_motion_error(self, client, server_proc):
-        """Motion commands on a halted controller raise MotionError, not -1."""
+    def test_estopped_motion_raises_motion_error(self, client, server_proc):
+        """Motion commands on an estopped controller raise MotionError until
+        reset() clears the latch."""
         from parol6.utils.errors import MotionError
 
-        client.halt()
+        client.estop()
         try:
             with pytest.raises(MotionError) as exc_info:
                 client.home()
             assert exc_info.value.robot_error.code > 0
             assert exc_info.value.robot_error.title
         finally:
-            client.resume()
+            client.reset()
 
     def test_rapid_command_sequence(self, server_proc, ports):
         """Test server stability under rapid command sequence."""

--- a/tests/integration/test_unhomed_motion_gate.py
+++ b/tests/integration/test_unhomed_motion_gate.py
@@ -1,0 +1,50 @@
+"""Planned motion is refused until the robot is homed.
+
+Before homing, reported joint positions are unreferenced (the boot state is
+all-zeros steps — outside J2/J3's limits and physically impossible), so
+planning or collision-checking a trajectory from them produces garbage:
+found live as a phantom "[54] Self-collision predicted" on a first move
+from the boot pose. Planned moves must instead be refused with an
+actionable "not homed" error; jogging stays allowed (an unhomed arm may
+need to be nudged clear of something before it can home), and ``home``
+itself is the way out.
+"""
+
+import pytest
+
+from parol6 import MotionError, RobotClient
+from parol6.utils.error_codes import ErrorCode
+
+pytestmark = pytest.mark.integration
+
+
+def test_planned_motion_refused_until_homed(client: RobotClient, server_proc):
+    """move_j from the unhomed boot state raises MOTN_NOT_HOMED (not a
+    garbage collision prediction); after homing the same move is accepted.
+    Jog remains available while unhomed."""
+    target = [90.0, -90.0, 180.0, 0.0, 0.0, 170.0]
+
+    # The autouse fixture homes; reset back to the unhomed boot state
+    # (Homed_in and Position_in zeroed — exactly how a controller starts).
+    # Then wait for the status stream to reflect the reset: a stale pre-reset
+    # frame still carries the fixture's completed_index, which would satisfy
+    # wait_command for the recycled index 0 before the refusal arrives.
+    client.reset()
+    assert client.wait_status(lambda s: s.completed_index < 0, timeout=5.0), (
+        "status stream never reflected the reset"
+    )
+
+    # The STATUS stream reports the unhomed state (WC feeds it to dry runs).
+    assert client.wait_status(lambda s: not s.homed, timeout=2.0)
+
+    with pytest.raises(MotionError, match="not homed") as exc_info:
+        client.move_j(target, duration=1.5, wait=True)
+    assert exc_info.value.robot_error.code == int(ErrorCode.MOTN_NOT_HOMED)
+
+    # Jogging an unhomed robot stays allowed — no planning involved.
+    assert client.jog_j(0, 0.2, 0.1) >= 0
+
+    # Homing establishes references; the identical move now proceeds.
+    assert client.home(wait=True, timeout=30.0) >= 0
+    assert client.wait_status(lambda s: s.homed, timeout=2.0)
+    assert client.move_j(target, duration=1.5, wait=True) >= 0

--- a/tests/integration/test_unhomed_motion_gate.py
+++ b/tests/integration/test_unhomed_motion_gate.py
@@ -26,13 +26,7 @@ def test_planned_motion_refused_until_homed(client: RobotClient, server_proc):
 
     # The autouse fixture homes; reset back to the unhomed boot state
     # (Homed_in and Position_in zeroed — exactly how a controller starts).
-    # Then wait for the status stream to reflect the reset: a stale pre-reset
-    # frame still carries the fixture's completed_index, which would satisfy
-    # wait_command for the recycled index 0 before the refusal arrives.
     client.reset()
-    assert client.wait_status(lambda s: s.completed_index < 0, timeout=5.0), (
-        "status stream never reflected the reset"
-    )
 
     # The STATUS stream reports the unhomed state (WC feeds it to dry runs).
     assert client.wait_status(lambda s: not s.homed, timeout=2.0)

--- a/tests/integration/test_unhomed_motion_gate.py
+++ b/tests/integration/test_unhomed_motion_gate.py
@@ -26,7 +26,7 @@ def test_planned_motion_refused_until_homed(client: RobotClient, server_proc):
 
     # The autouse fixture homes; reset back to the unhomed boot state
     # (Homed_in and Position_in zeroed — exactly how a controller starts).
-    client.reset()
+    client.reset_state()
 
     # The STATUS stream reports the unhomed state (WC feeds it to dry runs).
     assert client.wait_status(lambda s: not s.homed, timeout=2.0)

--- a/tests/unit/test_controller_system_commands.py
+++ b/tests/unit/test_controller_system_commands.py
@@ -70,11 +70,11 @@ class TestSystemCommandSideEffects:
         assert cmd._switch_port is None
 
     def test_reset_command_sets_sync_mock(self):
-        """Verify RESET command sets _sync_mock attribute."""
-        from parol6.commands.utility_commands import ResetCommand
-        from parol6.protocol.wire import ResetCmd
+        """Verify RESET_STATE command sets _sync_mock attribute."""
+        from parol6.commands.utility_commands import ResetStateCommand
+        from parol6.protocol.wire import ResetStateCmd
 
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         state = ControllerState()
 
         code = cmd.execute_step(state)

--- a/tests/unit/test_dry_run_script_compat.py
+++ b/tests/unit/test_dry_run_script_compat.py
@@ -118,3 +118,29 @@ class TestDryRunScriptCompat:
     def test_wait_motion(self, client):
         client.move_j(ANGLES_A, speed=0.5)
         client.wait_motion()
+
+
+class TestDryRunHomedGate:
+    """The dry run mirrors the live unhomed-motion gate: seeded from an
+    unhomed robot, planned moves are refused with the actionable not-homed
+    error (not a garbage collision prediction from unreferenced positions);
+    a home() in the script establishes references and later moves plan
+    cleanly."""
+
+    def test_unhomed_seed_gates_planned_moves_until_home(self):
+        client = DryRunRobotClient(initial_joints_deg=[0.0] * 6, initial_homed=False)
+
+        result = client.move_j(ANGLES_A, speed=0.5)
+        assert result is not None and result.error is not None
+        assert "not homed" in str(result.error)
+
+        # home() snaps to the home pose and establishes references —
+        # the first move after it must NOT error.
+        assert client.home().error is None
+        result = client.move_j(ANGLES_A, speed=0.5)
+        assert result is not None and result.error is None
+
+    def test_homed_seed_plans_immediately(self):
+        client = DryRunRobotClient(initial_joints_deg=HOME, initial_homed=True)
+        result = client.move_j(ANGLES_A, speed=0.5)
+        assert result is not None and result.error is None

--- a/tests/unit/test_dry_run_script_compat.py
+++ b/tests/unit/test_dry_run_script_compat.py
@@ -144,3 +144,20 @@ class TestDryRunHomedGate:
         client = DryRunRobotClient(initial_joints_deg=HOME, initial_homed=True)
         result = client.move_j(ANGLES_A, speed=0.5)
         assert result is not None and result.error is None
+
+    def test_referenced_home_previews_as_return_move(self):
+        import numpy as np
+
+        client = DryRunRobotClient(initial_joints_deg=ANGLES_A, initial_homed=True)
+        result = client.home()
+        assert result is not None and result.error is None
+        assert result.duration > 0.0
+        assert len(result.joint_trajectory_rad) > 1
+        assert np.allclose(np.degrees(result.end_joints_rad), HOME, atol=0.5)
+
+        # Unreferenced seed keeps the instant snap — the switch-seek can't
+        # be previewed from unreferenced positions.
+        client = DryRunRobotClient(initial_joints_deg=[0.0] * 6, initial_homed=False)
+        result = client.home()
+        assert result is not None and result.error is None
+        assert result.duration == 0.0

--- a/tests/unit/test_motion_pipeline.py
+++ b/tests/unit/test_motion_pipeline.py
@@ -104,21 +104,28 @@ class TestPlannerDirect:
         assert seg.command_index == 0
         assert isinstance(seg.params, SelectToolCmd)
 
-    def test_home_produces_inline_and_updates_position(self, worker, segment_queue):
-        """Home command should produce InlineSegment and update planner position."""
-        # Start from non-home position
-        worker.state.Position_in[:] = _deg_to_steps(W1)
+    def test_home_routes_by_referenced_state(self, worker, segment_queue):
+        """Unhomed HOME passes through as an InlineSegment (firmware
+        sequence); already-homed HOME fast-paths to a planned return
+        trajectory. Both leave the planner's predicted position at home."""
         home_steps = _home_steps()
 
-        params = HomeCmd()
-        msg = PlanCommand(command_index=0, params=params)
-
-        worker.process_command(msg)
-
+        worker.state.Position_in[:] = _deg_to_steps(W1)
+        worker.process_command(
+            PlanCommand(command_index=0, params=HomeCmd(), homed=False)
+        )
         seg = segment_queue.get(timeout=1.0)
         assert isinstance(seg, InlineSegment)
-        # Planner's position should now be home
         np.testing.assert_array_equal(worker.state.Position_in, home_steps)
+
+        worker.state.Position_in[:] = _deg_to_steps(W1)
+        worker.process_command(
+            PlanCommand(command_index=1, params=HomeCmd(), homed=True)
+        )
+        seg = segment_queue.get(timeout=1.0)
+        assert isinstance(seg, TrajectorySegment)
+        np.testing.assert_allclose(seg.trajectory_steps[-1], home_steps, atol=2)
+        np.testing.assert_allclose(worker.state.Position_in, home_steps, atol=2)
 
     def test_checkpoint_produces_inline_segment(self, worker, segment_queue):
         """Checkpoint should produce an InlineSegment."""

--- a/tests/unit/test_reset_command.py
+++ b/tests/unit/test_reset_command.py
@@ -1,15 +1,15 @@
-"""Tests for RESET command."""
+"""Tests for RESET_STATE command."""
 
 import numpy as np
 import pytest
 
-from parol6.commands.utility_commands import ResetCommand
-from parol6.protocol.wire import ResetCmd
+from parol6.commands.utility_commands import ResetStateCommand
+from parol6.protocol.wire import ResetStateCmd
 from parol6.server.state import ControllerState
 
 
 class TestResetCommandExecution:
-    """Test ResetCommand.tick resets state correctly."""
+    """Test ResetStateCommand.tick resets state correctly."""
 
     def test_reset_clears_positions(self):
         """Reset should zero out position buffers."""
@@ -19,7 +19,7 @@ class TestResetCommandExecution:
         )
         state.Speed_in = np.array([10, 20, 30, 40, 50, 60], dtype=np.int32)
 
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         cmd.tick(state)  # Reset executes in tick
 
         assert np.all(state.Position_in == 0)
@@ -32,7 +32,7 @@ class TestResetCommandExecution:
         state.soft_error = True
         state.disabled_reason = "some error"
 
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         cmd.tick(state)
 
         assert state.e_stop_active is False
@@ -44,7 +44,7 @@ class TestResetCommandExecution:
         state = ControllerState()
         state._current_tool = "GRIPPER"
 
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         cmd.tick(state)
 
         assert state._current_tool == "NONE"
@@ -57,7 +57,7 @@ class TestResetCommandExecution:
         state.start_time = 12345.0
         state.ser = "mock_serial"
 
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         cmd.tick(state)
 
         assert state.ip == "192.168.1.100"
@@ -68,7 +68,7 @@ class TestResetCommandExecution:
     def test_reset_finishes_immediately(self):
         """Reset command should complete in single tick."""
         state = ControllerState()
-        cmd = ResetCommand(ResetCmd())
+        cmd = ResetStateCommand(ResetStateCmd())
         cmd.tick(state)
 
         assert cmd.is_finished is True
@@ -80,11 +80,11 @@ class TestResetIntegration:
 
     def test_reset_command_succeeds(self, client, server_proc):
         """Test reset command executes successfully via client."""
-        result = client.reset()
+        result = client.reset_state()
         assert result > 0
 
     def test_reset_multiple_times(self, client, server_proc):
         """Test reset can be called multiple times."""
         for _ in range(3):
-            result = client.reset()
+            result = client.reset_state()
             assert result > 0

--- a/tests/unit/test_ruckig_bypass.py
+++ b/tests/unit/test_ruckig_bypass.py
@@ -28,6 +28,8 @@ class MockState:
         self.Speed_out = np.zeros(6, dtype=np.int32)
         self.Command_out = 0
         self.motion_profile = "TOPPRA"
+        # Sitting at the home position — a homed robot (planned moves gate on it).
+        self.Homed_in = np.ones(8, dtype=np.uint8)
 
 
 class TestPrecomputedTrajectories:


### PR DESCRIPTION
Refuses planned motion while unhomed; keeps command indices monotonic across reset; fast-paths `home()` on a referenced robot into a planned collision-checked return move; replaces halt/resume with stop/estop/reset and makes stops actually cancel the in-flight trajectory (previously the segment player kept playing through a halt, so a "halted" robot drove on to its target). Requires waldoctl `feat/mcp-server` (CI branch-matches; release train: waldoctl tag → pin bump here → tag).

Written by Claude on behalf of @Jepson2k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbP8n8tzaJXKMjkRxGnoa1