### PR TITLE
Gate trajectory settling on progress, not elapsed ticks

### DIFF
--- a/parol6/motion/geometry.py
+++ b/parol6/motion/geometry.py
@@ -192,9 +192,10 @@ class SplineMotion(_ShapeGenerator):
 
         pos_splines = []
         for i in range(3):
-            bc: Any
+            # Annotated assignment keeps bc as Any: scipy-stubs' bc_type rejects
+            # the scalar derivative values scipy requires for 1-D y
             if velocity_start is not None and velocity_end is not None:
-                bc = ((1, float(velocity_start[i])), (1, float(velocity_end[i])))
+                bc: Any = ((1, float(velocity_start[i])), (1, float(velocity_end[i])))
             else:
                 bc = "not-a-knot"
             spline = CubicSpline(timestamps_arr, waypoints_arr[:, i], bc_type=bc)

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 def _enc_hook(obj: object) -> object:
     """Custom encoder hook for numpy types."""
     if isinstance(obj, np.ndarray):
-        return obj.tolist()  # type: ignore[no-matching-overload, ty:no-matching-overload]
+        return obj.tolist()  # type: ignore[no-matching-overload]
     if isinstance(obj, (np.integer, np.floating)):
         return obj.item()
     raise NotImplementedError(f"Cannot encode {type(obj)}")

--- a/parol6/server/segment_player.py
+++ b/parol6/server/segment_player.py
@@ -17,7 +17,6 @@ from collections import deque
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pinokin import arrays_equal_n
 
 from parol6.commands._collision_guard import guard_joint_path
 from parol6.commands.base import CommandBase, ExecutionStatusCode
@@ -60,6 +59,7 @@ class SegmentPlayer:
         "_inline_activated",
         "_settling",
         "_settle_ticks",
+        "_settle_err",
         "_last_shapes_version",
     )
 
@@ -72,6 +72,7 @@ class SegmentPlayer:
         self._inline_activated: bool = False
         self._settling: bool = False
         self._settle_ticks: int = 0
+        self._settle_err: int = -1
         self._last_shapes_version: int = 0
 
     @property
@@ -127,16 +128,36 @@ class SegmentPlayer:
                     self._step += 1
                     self._settling = False
                     return True
-                # All waypoints sent — hold MOVE at target until Position_in converges
+                # All waypoints sent — hold MOVE at target until Position_in
+                # converges. The tick cap gates on stall, not elapsed time:
+                # while the firmware is still closing on the target (e.g. it
+                # fell behind the waypoint stream under CPU starvation) the
+                # segment stays active, so completion is never reported with
+                # the robot still in motion.
                 target = active.trajectory_steps[-1]
                 if not self._settling:
                     self._settling = True
                     self._settle_ticks = 0
+                    self._settle_err = -1
+                err = 0
+                for i in range(6):
+                    d = int(state.Position_in[i]) - int(target[i])
+                    if d < 0:
+                        d = -d
+                    if d > err:
+                        err = d
+                if self._settle_err < 0 or err < self._settle_err:
+                    self._settle_err = err
+                    self._settle_ticks = 0
                 self._settle_ticks += 1
-                if (
-                    arrays_equal_n(state.Position_in[:6], target[:6])
-                    or self._settle_ticks > SETTLE_MAX_TICKS
-                ):
+                if err == 0 or self._settle_ticks > SETTLE_MAX_TICKS:
+                    if err != 0:
+                        logger.warning(
+                            "Segment completed %d steps short of target "
+                            "(no settle progress for %d ticks)",
+                            err,
+                            SETTLE_MAX_TICKS,
+                        )
                     self._settling = False
                     self._complete_segment(active, state)
                     continue

--- a/parol6/server/transports/serial_transport.py
+++ b/parol6/server/transports/serial_transport.py
@@ -8,7 +8,6 @@ data exchange with the robot hardware.
 import logging
 import os
 import time
-from typing import cast
 
 import numba
 import numpy as np
@@ -415,9 +414,7 @@ class SerialTransport:
         Return a tuple of (memoryview|None, version:int, timestamp:float).
         The memoryview points to a stable 52-byte buffer which is updated by the reader.
         """
-        mv = cast(
-            "memoryview | None", self._frame_mv if self._frame_version > 0 else None
-        )
+        mv = self._frame_mv if self._frame_version > 0 else None
         return (mv, self._frame_version, self._frame_ts)
 
     def _update_hz_tracking(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "trimesh",
     "fast-simplification",
     "rtree",
-    "scipy-stubs",
+    "scipy-stubs==1.18.0.1",
     "types-pyserial",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev = [
     "trimesh",
     "fast-simplification",
     "rtree",
-    "scipy-stubs==1.18.0.1",
+    "scipy-stubs==1.17.1.5; python_version < '3.12'",
+    "scipy-stubs==1.18.0.1; python_version >= '3.12'",
     "types-pyserial",
 ]
 


### PR DESCRIPTION
The segment player's settle phase completed a trajectory after a fixed 20-tick cap even when the firmware was still closing on the target, and the mock transport freezes all residual motion once the command stream goes idle. On a CPU-starved host the simulated plant falls behind the waypoint stream, the cap fires, and the command is reported complete with the robot stranded short of its target — observed in Waldo-Commander's hand-eye CI (Jepson2k/Waldo-Commander#29), where a `home(wait=True)` "completed" with J1 still 29° from standby and subsequent relative moves then ran out of joint range.

Settling now resets the tick counter whenever the position error shrinks, so the cap only fires after 20 ticks with **no** progress. This preserves the anti-hang escape for real hardware's steady-state residual (error stops changing → escape after 200 ms, as before), while a plant that is still converging is always allowed to finish — completion is never reported mid-motion. An unconverged completion now logs a warning with the residual step count instead of passing silently.

Verified with the parol6 suite (275 passed) and the full Waldo-Commander suite against this branch (312 passed). Also included on `claude/eye-hand-calibration-waldo-nrb1sf` (#28) so the WC PR's CI picks it up via branch matching; merging this PR first will shrink #28 back to its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdLG1uiKKZJ6aAeiojeRwd