### PR TITLE
Fix SystemCommand Command_out getting clobbered same-tick by exec fallback

### DIFF
--- a/parol6/server/controller.py
+++ b/parol6/server/controller.py
@@ -385,6 +385,11 @@ class Controller:
         # Streaming command executor (jog/servo)
         if self._executor.active_command or self._executor.command_queue:
             self._executor.execute_active_command()
+        elif state.command_out_locked:
+            # A SystemCommand (e.g. RESET) set Command_out earlier this same
+            # tick during poll_cmd -- consume the lock instead of stomping
+            # it back to IDLE before _write_to_firmware() sees it.
+            state.command_out_locked = False
         else:
             state.Command_out = CommandCode.IDLE
             state.Speed_out.fill(0)
@@ -591,6 +596,7 @@ class Controller:
         """Poll and process UDP commands (non-blocking)."""
         assert self.udp_transport is not None
 
+        state.command_out_locked = False
         msgs = self.udp_transport.poll_receive_all(max_count=MAX_POLL_COUNT)
         for data, addr in msgs:
             self._process_command(data, addr, state)
@@ -801,6 +807,13 @@ class Controller:
         try:
             command.setup(state)
             code = command.tick(state)
+
+            # This SystemCommand set a real signal (e.g. RESET's ENABLE) for
+            # firmware to see on this tick's write phase -- don't let
+            # _execute_commands()'s later "nothing active" fallback stomp it
+            # back to IDLE before _write_to_firmware() runs.
+            if state.Command_out != CommandCode.IDLE:
+                state.command_out_locked = True
 
             # Stop/estop: cancel the motion pipeline, or the segment player
             # keeps playing the active trajectory (rewriting Command_out and

--- a/parol6/server/state.py
+++ b/parol6/server/state.py
@@ -184,6 +184,18 @@ class ControllerState:
     # Robot telemetry and command buffers - using ndarray for efficiency
     Command_out: CommandCode = CommandCode.IDLE  # The command code to send to firmware
 
+    # True for the remainder of the tick in which a SystemCommand (RESET's
+    # ENABLE, ESTOP/STOP's IDLE, etc.) explicitly set Command_out to a
+    # meaningful value during poll_cmd. Without this, _execute_commands()'s
+    # "nothing active" fallback (which also runs every tick, after poll_cmd)
+    # unconditionally overwrites Command_out back to IDLE before
+    # _write_to_firmware() ever sees the SystemCommand's signal -- so e.g.
+    # RESET's ENABLE(101) never actually reaches the firmware, leaving
+    # PAROL6.disabled latched from an earlier ESTOP forever. Reset to False
+    # at the top of every _poll_commands() call; consumed (and cleared) by
+    # _execute_commands()'s fallback the same tick it's set.
+    command_out_locked: bool = False
+
     Position_out: np.ndarray = field(
         default_factory=lambda: np.zeros((6,), dtype=np.int32)
     )

--- a/tests/unit/test_reset_enable_reaches_firmware.py
+++ b/tests/unit/test_reset_enable_reaches_firmware.py
@@ -1,0 +1,78 @@
+"""Regression test: a SystemCommand's Command_out must survive to the write phase.
+
+RESET sets ``Command_out = ENABLE`` during poll_cmd so the firmware can clear
+a latched ``disabled``. ``_execute_commands()`` runs later the same tick, and
+its "nothing active" fallback used to overwrite Command_out back to IDLE
+before ``_write_to_firmware()`` ran — so the ENABLE never reached the wire and
+the robot stayed firmware-disabled after every RESET.
+"""
+
+import socket
+import time
+
+import pytest
+
+from parol6.protocol.wire import CommandCode, EstopCmd, ResetCmd, encode_command
+from parol6.server.controller import Controller, ControllerConfig
+
+
+@pytest.fixture
+def controller():
+    ctl = Controller(ControllerConfig(udp_host="127.0.0.1", udp_port=0))
+    try:
+        yield ctl
+    finally:
+        if ctl.udp_transport is not None:
+            ctl.udp_transport.close_socket()
+        if ctl._status_broadcaster is not None:
+            ctl._status_broadcaster.close()
+        ctl._transport_mgr.disconnect()
+        ctl.state_manager.reset_state()
+
+
+def test_reset_enable_reaches_firmware_write(controller):
+    """ESTOP then RESET over real UDP: the tick that dispatches RESET must
+    hand ENABLE to the transport write, not the executor fallback's IDLE."""
+    state = controller.state_manager.get_state()
+    assert controller.udp_transport is not None
+    port = controller.udp_transport.socket.getsockname()[1]
+
+    written: list[int] = []
+    real_write = controller._transport_mgr.write_frame
+
+    def tap(position_out, speed_out, command_out, *args):
+        written.append(command_out)
+        return real_write(position_out, speed_out, command_out, *args)
+
+    controller._transport_mgr.write_frame = tap
+
+    def tick() -> None:
+        # The phases of _main_control_loop this bug lives in, in loop order.
+        # _handle_estop is omitted: it gates on serial-read state, and the
+        # protective-stop scenario has estop_active False, so execute runs.
+        controller._poll_commands(state)
+        controller._execute_commands(state)
+        controller._write_to_firmware(state)
+
+    def tick_until(condition, message: str) -> None:
+        for _ in range(200):
+            tick()
+            if condition():
+                return
+            time.sleep(0.005)
+        pytest.fail(message)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.sendto(encode_command(EstopCmd()), ("127.0.0.1", port))
+        tick_until(lambda: not state.enabled, "ESTOP was never dispatched")
+
+        sock.sendto(encode_command(ResetCmd()), ("127.0.0.1", port))
+        tick_until(lambda: state.enabled, "RESET was never dispatched")
+    finally:
+        sock.close()
+
+    assert CommandCode.ENABLE.value in written, (
+        "RESET's ENABLE never reached the firmware write phase — "
+        f"written command codes: {sorted(set(written))}"
+    )


### PR DESCRIPTION
## Summary
After an ESTOP latches `PAROL6.disabled` at the firmware level, `RESET` (and any `SystemCommand`) silently fails to re-enable the robot -- `HOME`/`JOG`/`MOVE` all get accepted, planned, and streamed with correct, smoothly-changing setpoints, and the server reports success throughout, but the arm never actually moves. No error is raised anywhere in the stack.

## Root cause
Each 100Hz control-loop tick runs `_poll_commands()` (dispatches `SystemCommand`s like RESET) before `_execute_commands()`. `_execute_commands()`'s "nothing active" fallback unconditionally sets `state.Command_out = CommandCode.IDLE` -- which clobbers `ResetCommand.execute_step()`'s `state.Command_out = CommandCode.ENABLE` before `_write_to_firmware()` ever observes it, on every single RESET call (RESET never queues an active segment, so it always hits this fallback branch). `ENABLE(101)` therefore never reaches the firmware, and `PAROL6.disabled` stays latched forever at the firmware's `if (PAROL6.disabled == 0) {...}` gate -- while every higher layer (planner, segment player, server) believes the command succeeded.

Found via live per-tick instrumentation of the pipeline (`_handle_motion_command` -> `planner.submit` -> subprocess -> `segment_queue` -> `SegmentPlayer.tick`/`_activate_next` -> `_write_to_firmware`) rather than static reading, which had repeatedly given false confidence at every layer.

## Fix
`ControllerState` gains `command_out_locked: bool = False`:
- `_poll_commands()` resets it to `False` at the top of every tick.
- `_handle_system_command()` sets it `True` after `command.tick(state)` if `state.Command_out != CommandCode.IDLE`.
- `_execute_commands()`'s fallback checks the lock first -- if set, it consumes it (`= False`) instead of stomping `Command_out` back to `IDLE`.

## Testing
- `home()` verified on real hardware: robot genuinely drives to standby, confirmed both via continuous `status().angles` polling during the move and by physically observing it.
- Full existing test suite passes unchanged: `python3 -m pytest -q -m "unit or integration"` (90 tests).

## Open item
Whether the same same-tick clobbering affects STOP/ESTOP's own `Command_out` assignments wasn't independently verified -- their handling additionally calls `_segment_player.cancel()`/`_executor.cancel_active_command()`, which may sidestep the issue differently, but I haven't confirmed either way. Flagging for review/follow-up rather than asserting it's fine.