### PR TITLE
Bump waldoctl pin to v0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.8.0",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.9.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.7.0",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.8.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Points the waldoctl dependency at v0.8.0 (waldoctl#14 — eye-hand calibration interface additions — merged and tagged).

Branch name matches the Waldo-Commander eye-hand branch so WC CI picks this up via branch-matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QrPR5eVhd31AvFpxJKr6