### PR TITLE
home(calibrate=): forced end-stop referencing on the waldoctl ABC; StatusBuffer/loop_stats/homing-progress conformance

### DIFF
--- a/parol6/ack_policy.py
+++ b/parol6/ack_policy.py
@@ -52,7 +52,6 @@ FIRE_AND_FORGET: set[CmdType] = {
 # Queued motion commands that return a command index in their ACK
 QUEUED_CMD_TYPES: set[CmdType] = {
     CmdType.HOME,
-    CmdType.CALIBRATE,
     CmdType.MOVEJ,
     CmdType.MOVEJ_POSE,
     CmdType.MOVEL,

--- a/parol6/ack_policy.py
+++ b/parol6/ack_policy.py
@@ -52,6 +52,7 @@ FIRE_AND_FORGET: set[CmdType] = {
 # Queued motion commands that return a command index in their ACK
 QUEUED_CMD_TYPES: set[CmdType] = {
     CmdType.HOME,
+    CmdType.CALIBRATE,
     CmdType.MOVEJ,
     CmdType.MOVEJ_POSE,
     CmdType.MOVEL,

--- a/parol6/client/async_client.py
+++ b/parol6/client/async_client.py
@@ -42,6 +42,7 @@ from ..protocol.wire import (
     JointSpeedsCmd,
     LoopStatsCmd,
     EstopCmd,
+    CalibrateCmd,
     HomeCmd,
     JogJCmd,
     JogLCmd,
@@ -682,6 +683,32 @@ class AsyncRobotClient(_RobotClientABC):
             ok = await self.wait_command(index, timeout=timeout)
             if not ok:
                 raise TimeoutError(f"home() timed out after {timeout}s")
+        return index
+
+    async def calibrate(self, wait: bool = False, timeout: float = 60.0) -> int:
+        """Run the end-stop referencing sequence, even if already referenced.
+
+        Each joint seeks its limit switch to re-derive joint zero, then the
+        robot moves to standby. Use home() to return to standby without
+        re-referencing.
+
+        Returns the command index (≥ 0) on success, -1 on failure.
+
+        Category: Motion
+
+        Example:
+            rbt.calibrate(wait=True)
+
+        Args:
+            wait: If True, block until the sequence completes
+            timeout: Maximum time to wait in seconds (only used when wait=True)
+        """
+        index = await self._send(CalibrateCmd())
+        assert isinstance(index, int)
+        if wait and index >= 0:
+            ok = await self.wait_command(index, timeout=timeout)
+            if not ok:
+                raise TimeoutError(f"calibrate() timed out after {timeout}s")
         return index
 
     async def stop(self) -> int:

--- a/parol6/client/async_client.py
+++ b/parol6/client/async_client.py
@@ -16,7 +16,7 @@ import msgspec
 import numpy as np
 from waldoctl import RobotClient as _RobotClientABC, Shape, ShapeWorld, ToolStatus
 from waldoctl.shapes import shape_from_wire
-from waldoctl.status import ActionState, ActivityResult, ToolResult
+from waldoctl.status import ActionState, ActivityResult, LoopStatsResult, ToolResult
 from waldoctl.tools import ToolSpec
 
 from .. import config as cfg
@@ -42,7 +42,6 @@ from ..protocol.wire import (
     JointSpeedsCmd,
     LoopStatsCmd,
     EstopCmd,
-    CalibrateCmd,
     HomeCmd,
     JogJCmd,
     JogLCmd,
@@ -658,13 +657,21 @@ class AsyncRobotClient(_RobotClientABC):
     # --------------- Motion / Control ---------------
 
     async def home(
-        self, wait: bool = False, timeout: float = 60.0, **wait_kwargs: Any
+        self,
+        wait: bool = False,
+        calibrate: bool = False,
+        timeout: float = 60.0,
+        **wait_kwargs: Any,
     ) -> int:
         """Home the robot to its home position.
 
-        Unhomed, this runs the full referencing sequence (each joint seeks
-        its limit switch, then moves to standby). Already homed, it returns
-        to standby with a normal planned, collision-checked joint move.
+        Uncalibrated (first home after power-on), this runs the full
+        referencing sequence: each joint seeks its limit switch, then the
+        robot moves to standby. Calibrated, it returns to standby with a
+        normal planned, collision-checked joint move — unless
+        ``calibrate=True``, which re-runs the referencing sequence. The
+        referencing sequence is firmware-driven and ignores the collision
+        world, so clear keep-out geometry from the joints' sweep first.
 
         Returns the command index (≥ 0) on success, -1 on failure.
 
@@ -675,40 +682,15 @@ class AsyncRobotClient(_RobotClientABC):
 
         Args:
             wait: If True, block until motion completes
+            calibrate: If True, always run the referencing sequence
             timeout: Maximum time to wait in seconds (only used when wait=True)
         """
-        index = await self._send(HomeCmd())
+        index = await self._send(HomeCmd(calibrate=calibrate))
         assert isinstance(index, int)
         if wait and index >= 0:
             ok = await self.wait_command(index, timeout=timeout)
             if not ok:
                 raise TimeoutError(f"home() timed out after {timeout}s")
-        return index
-
-    async def calibrate(self, wait: bool = False, timeout: float = 60.0) -> int:
-        """Run the end-stop referencing sequence, even if already referenced.
-
-        Each joint seeks its limit switch to re-derive joint zero, then the
-        robot moves to standby. Use home() to return to standby without
-        re-referencing.
-
-        Returns the command index (≥ 0) on success, -1 on failure.
-
-        Category: Motion
-
-        Example:
-            rbt.calibrate(wait=True)
-
-        Args:
-            wait: If True, block until the sequence completes
-            timeout: Maximum time to wait in seconds (only used when wait=True)
-        """
-        index = await self._send(CalibrateCmd())
-        assert isinstance(index, int)
-        if wait and index >= 0:
-            ok = await self.wait_command(index, timeout=timeout)
-            if not ok:
-                raise TimeoutError(f"calibrate() timed out after {timeout}s")
         return index
 
     async def stop(self) -> int:
@@ -918,7 +900,7 @@ class AsyncRobotClient(_RobotClientABC):
         resp = await self._request(StatusCmd())
         return resp if isinstance(resp, StatusResultStruct) else None
 
-    async def loop_stats(self) -> LoopStatsResultStruct | None:
+    async def loop_stats(self) -> LoopStatsResult | None:
         """Fetch control-loop runtime metrics.
 
         Category: Query
@@ -927,7 +909,27 @@ class AsyncRobotClient(_RobotClientABC):
             stats = rbt.loop_stats()
         """
         resp = await self._request(LoopStatsCmd())
-        return resp if isinstance(resp, LoopStatsResultStruct) else None
+        if not isinstance(resp, LoopStatsResultStruct):
+            return None
+        # No fieldbus and no real-time scheduling on this backend.
+        return LoopStatsResult(
+            target_hz=resp.target_hz,
+            loop_count=resp.loop_count,
+            overrun_count=resp.overrun_count,
+            mean_period_s=resp.mean_period_s,
+            std_period_s=resp.std_period_s,
+            min_period_s=resp.min_period_s,
+            max_period_s=resp.max_period_s,
+            p95_period_s=resp.p95_period_s,
+            p99_period_s=resp.p99_period_s,
+            mean_hz=resp.mean_hz,
+            p50_period_s=resp.p50_period_s,
+            p90_period_s=resp.p90_period_s,
+            can_frame_age_min_ticks=0,
+            can_frame_age_max_ticks=0,
+            rt_fifo=False,
+            rt_pinned=False,
+        )
 
     async def reset_loop_stats(self) -> int:
         """Reset control-loop min/max metrics and overrun count.

--- a/parol6/client/async_client.py
+++ b/parol6/client/async_client.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, cast
 import msgspec
 import numpy as np
 from waldoctl import RobotClient as _RobotClientABC, Shape, ShapeWorld, ToolStatus
+from msgspec.structs import asdict
 from waldoctl.shapes import shape_from_wire
 from waldoctl.status import ActionState, ActivityResult, LoopStatsResult, ToolResult
 from waldoctl.tools import ToolSpec
@@ -913,18 +914,7 @@ class AsyncRobotClient(_RobotClientABC):
             return None
         # No fieldbus and no real-time scheduling on this backend.
         return LoopStatsResult(
-            target_hz=resp.target_hz,
-            loop_count=resp.loop_count,
-            overrun_count=resp.overrun_count,
-            mean_period_s=resp.mean_period_s,
-            std_period_s=resp.std_period_s,
-            min_period_s=resp.min_period_s,
-            max_period_s=resp.max_period_s,
-            p95_period_s=resp.p95_period_s,
-            p99_period_s=resp.p99_period_s,
-            mean_hz=resp.mean_hz,
-            p50_period_s=resp.p50_period_s,
-            p90_period_s=resp.p90_period_s,
+            **asdict(resp),
             can_frame_age_min_ticks=0,
             can_frame_age_max_ticks=0,
             rt_fifo=False,

--- a/parol6/client/dry_run_client.py
+++ b/parol6/client/dry_run_client.py
@@ -39,6 +39,7 @@ import re as _re
 
 import parol6.protocol.wire as _wire
 from ..protocol.wire import (
+    CalibrateCmd,
     HomeCmd,
     SelectToolCmd,
     SetTcpOffsetCmd,
@@ -249,6 +250,8 @@ class DryRunRobotClient:
 
     def _dispatch(self, params: Any) -> DryRunResult | None:
         """Route a command struct through the trajectory planner."""
+        if isinstance(params, CalibrateCmd):
+            return self._snap_to_angles(HOME_ANGLES_DEG)
         if isinstance(params, HomeCmd):
             if not self._planner.state.Homed_in[:6].all():
                 return self._snap_to_angles(HOME_ANGLES_DEG)

--- a/parol6/client/dry_run_client.py
+++ b/parol6/client/dry_run_client.py
@@ -39,7 +39,6 @@ import re as _re
 
 import parol6.protocol.wire as _wire
 from ..protocol.wire import (
-    CalibrateCmd,
     HomeCmd,
     SelectToolCmd,
     SetTcpOffsetCmd,
@@ -250,10 +249,8 @@ class DryRunRobotClient:
 
     def _dispatch(self, params: Any) -> DryRunResult | None:
         """Route a command struct through the trajectory planner."""
-        if isinstance(params, CalibrateCmd):
-            return self._snap_to_angles(HOME_ANGLES_DEG)
         if isinstance(params, HomeCmd):
-            if not self._planner.state.Homed_in[:6].all():
+            if params.calibrate or not self._planner.state.Homed_in[:6].all():
                 return self._snap_to_angles(HOME_ANGLES_DEG)
             # Already referenced → fall through: the planner fast-paths HOME
             # into a planned return move, so the preview renders the path.

--- a/parol6/client/sync_client.py
+++ b/parol6/client/sync_client.py
@@ -14,12 +14,11 @@ from typing import Any, TypeVar, overload
 from waldoctl.tools import ToolSpec
 
 from waldoctl import PingResult, ToolStatus
-from waldoctl.status import ActivityResult, ToolResult
+from waldoctl.status import ActivityResult, LoopStatsResult, ToolResult
 
 from waldoctl.types import Axis, Frame
 from ..protocol.wire import (
     EnablementResultStruct,
-    LoopStatsResultStruct,
     StatusBuffer,
     StatusResultStruct,
 )
@@ -175,33 +174,27 @@ class RobotClient:
 
     # ---------- motion / control ----------
 
-    def home(self, wait: bool = False, timeout: float = 60.0) -> int:
+    def home(
+        self, wait: bool = False, calibrate: bool = False, timeout: float = 60.0
+    ) -> int:
         """Home the robot to its home position.
 
-        Unhomed, this runs the full referencing sequence (each joint seeks
-        its limit switch, then moves to standby). Already homed, it returns
-        to standby with a normal planned, collision-checked joint move.
+        Uncalibrated (first home after power-on), this runs the full
+        referencing sequence: each joint seeks its limit switch, then the
+        robot moves to standby. Calibrated, it returns to standby with a
+        normal planned, collision-checked joint move — unless
+        ``calibrate=True``, which re-runs the referencing sequence. The
+        referencing sequence is firmware-driven and ignores the collision
+        world, so clear keep-out geometry from the joints' sweep first.
 
         Returns the command index (≥ 0) on success, -1 on failure.
 
         Args:
             wait: If True, block until motion completes.
+            calibrate: If True, always run the referencing sequence.
             timeout: Maximum time to wait in seconds (only used when wait=True).
         """
-        return _run(self._inner.home(wait=wait, timeout=timeout))
-
-    def calibrate(self, wait: bool = False, timeout: float = 60.0) -> int:
-        """Run the end-stop referencing sequence, even if already referenced.
-
-        Each joint seeks its limit switch to re-derive joint zero, then the
-        robot moves to standby. Use home() to return to standby without
-        re-referencing.
-
-        Args:
-            wait: If True, block until the sequence completes.
-            timeout: Maximum time to wait in seconds (only used when wait=True).
-        """
-        return _run(self._inner.calibrate(wait=wait, timeout=timeout))
+        return _run(self._inner.home(wait=wait, timeout=timeout, calibrate=calibrate))
 
     def teleport(
         self,
@@ -314,11 +307,11 @@ class RobotClient:
         """
         return _run(self._inner.status())
 
-    def loop_stats(self) -> LoopStatsResultStruct | None:
+    def loop_stats(self) -> LoopStatsResult | None:
         """Control loop runtime statistics.
 
         Returns:
-            LoopStatsResultStruct with loop timing metrics, or None on timeout.
+            LoopStatsResult with loop timing metrics, or None on timeout.
         """
         return _run(self._inner.loop_stats())
 

--- a/parol6/client/sync_client.py
+++ b/parol6/client/sync_client.py
@@ -190,6 +190,19 @@ class RobotClient:
         """
         return _run(self._inner.home(wait=wait, timeout=timeout))
 
+    def calibrate(self, wait: bool = False, timeout: float = 60.0) -> int:
+        """Run the end-stop referencing sequence, even if already referenced.
+
+        Each joint seeks its limit switch to re-derive joint zero, then the
+        robot moves to standby. Use home() to return to standby without
+        re-referencing.
+
+        Args:
+            wait: If True, block until the sequence completes.
+            timeout: Maximum time to wait in seconds (only used when wait=True).
+        """
+        return _run(self._inner.calibrate(wait=wait, timeout=timeout))
+
     def teleport(
         self,
         angles_deg: list[float],

--- a/parol6/commands/basic_commands.py
+++ b/parol6/commands/basic_commands.py
@@ -99,12 +99,12 @@ class HomeCommand(MotionCommand[HomeCmd]):
 
     def execute_step(self, state: "ControllerState") -> ExecutionStatusCode:
         """Manages the homing command and monitors for completion using a state machine."""
+        state.homing_step = self.state.value
         if self.state == HomeState.START:
             logger.debug(
                 "  -> Sending home signal (100)... Countdown: %d",
                 self.start_cmd_counter,
             )
-            state.homing_step = 1
             state.Command_out = CommandCode.HOME
             self.start_cmd_counter -= 1
             if self.start_cmd_counter <= 0:
@@ -112,31 +112,26 @@ class HomeCommand(MotionCommand[HomeCmd]):
             return ExecutionStatusCode.EXECUTING
 
         if self.state == HomeState.WAITING_FOR_UNHOMED:
-            state.homing_step = 2
             state.Command_out = CommandCode.IDLE
             if np.any(state.Homed_in[:6] == 0):
                 logger.info("  -> Homing sequence initiated by robot.")
                 self.state = HomeState.WAITING_FOR_HOMED
             self.timeout_counter -= 1
             if self.timeout_counter <= 0:
-                state.homing_step = 0
                 self.fail(make_error(ErrorCode.MOTN_HOME_TIMEOUT))
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.FAILED
             return ExecutionStatusCode.EXECUTING
 
         if self.state == HomeState.WAITING_FOR_HOMED:
-            state.homing_step = 3
             state.Command_out = CommandCode.IDLE
             if np.all(state.Homed_in[:6] == 1):
                 self.log_info("Homing sequence complete. All joints reported home.")
-                state.homing_step = 0
                 self.finish()
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.COMPLETED
             self.timeout_counter -= 1
             if self.timeout_counter <= 0:
-                state.homing_step = 0
                 self.fail(make_error(ErrorCode.MOTN_HOME_TIMEOUT))
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.FAILED

--- a/parol6/commands/basic_commands.py
+++ b/parol6/commands/basic_commands.py
@@ -17,7 +17,6 @@ from parol6.config import (
 )
 from parol6.protocol.wire import (
     CmdType,
-    CalibrateCmd,
     HomeCmd,
     JogJCmd,
     SelectToolCmd,
@@ -78,8 +77,10 @@ class HomeState(Enum):
 class HomeCommand(MotionCommand[HomeCmd]):
     """
     A non-blocking command that tells the robot to perform its internal homing sequence.
-    Reached only while the robot is unhomed — the planner routes HOME from an
-    already-referenced robot to a planned return move instead.
+    Reached while the robot is unhomed, or on HOME(calibrate=True) from a
+    referenced robot — the planner routes plain HOME from an already-referenced
+    robot to a planned return move instead. The firmware clears the homed bits
+    when the sequence starts, which WAITING_FOR_UNHOMED relies on.
     """
 
     PARAMS_TYPE = HomeCmd
@@ -103,6 +104,7 @@ class HomeCommand(MotionCommand[HomeCmd]):
                 "  -> Sending home signal (100)... Countdown: %d",
                 self.start_cmd_counter,
             )
+            state.homing_step = 1
             state.Command_out = CommandCode.HOME
             self.start_cmd_counter -= 1
             if self.start_cmd_counter <= 0:
@@ -110,39 +112,36 @@ class HomeCommand(MotionCommand[HomeCmd]):
             return ExecutionStatusCode.EXECUTING
 
         if self.state == HomeState.WAITING_FOR_UNHOMED:
+            state.homing_step = 2
             state.Command_out = CommandCode.IDLE
             if np.any(state.Homed_in[:6] == 0):
                 logger.info("  -> Homing sequence initiated by robot.")
                 self.state = HomeState.WAITING_FOR_HOMED
             self.timeout_counter -= 1
             if self.timeout_counter <= 0:
+                state.homing_step = 0
                 self.fail(make_error(ErrorCode.MOTN_HOME_TIMEOUT))
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.FAILED
             return ExecutionStatusCode.EXECUTING
 
         if self.state == HomeState.WAITING_FOR_HOMED:
+            state.homing_step = 3
             state.Command_out = CommandCode.IDLE
             if np.all(state.Homed_in[:6] == 1):
                 self.log_info("Homing sequence complete. All joints reported home.")
+                state.homing_step = 0
                 self.finish()
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.COMPLETED
             self.timeout_counter -= 1
             if self.timeout_counter <= 0:
+                state.homing_step = 0
                 self.fail(make_error(ErrorCode.MOTN_HOME_TIMEOUT))
                 self.stop_and_idle(state)
                 return ExecutionStatusCode.FAILED
 
         return ExecutionStatusCode.EXECUTING
-
-
-@register_command(CmdType.CALIBRATE)
-class CalibrateCommand(HomeCommand):
-    """Runs the firmware referencing sequence unconditionally — the planner
-    never substitutes a planned return move for CALIBRATE."""
-
-    PARAMS_TYPE = CalibrateCmd
 
 
 @register_command(CmdType.JOGJ)

--- a/parol6/commands/basic_commands.py
+++ b/parol6/commands/basic_commands.py
@@ -17,6 +17,7 @@ from parol6.config import (
 )
 from parol6.protocol.wire import (
     CmdType,
+    CalibrateCmd,
     HomeCmd,
     JogJCmd,
     SelectToolCmd,
@@ -134,6 +135,14 @@ class HomeCommand(MotionCommand[HomeCmd]):
                 return ExecutionStatusCode.FAILED
 
         return ExecutionStatusCode.EXECUTING
+
+
+@register_command(CmdType.CALIBRATE)
+class CalibrateCommand(HomeCommand):
+    """Runs the firmware referencing sequence unconditionally — the planner
+    never substitutes a planned return move for CALIBRATE."""
+
+    PARAMS_TYPE = CalibrateCmd
 
 
 @register_command(CmdType.JOGJ)

--- a/parol6/commands/query_commands.py
+++ b/parol6/commands/query_commands.py
@@ -176,6 +176,8 @@ class LoopStatsCommand(QueryCommand[LoopStatsCmd]):
                 p95_period_s=state.p95_period_s,
                 p99_period_s=state.p99_period_s,
                 mean_hz=mean_hz,
+                p50_period_s=state.p50_period_s,
+                p90_period_s=state.p90_period_s,
             )
         )
 

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -158,6 +158,8 @@ class CmdType(IntEnum):
     SET_SHAPES = auto()
     # Collision-world readback query (installation + program layers)
     SHAPES = auto()
+    # Forced end-stop referencing (appended last: values are wire tags)
+    CALIBRATE = auto()
 
 
 # =============================================================================
@@ -501,6 +503,19 @@ class HomeCmd(
     msgspec.Struct, tag=int(CmdType.HOME), array_like=True, frozen=True, gc=False
 ):
     """HOME: [CmdType.HOME]"""
+
+    pass
+
+
+class CalibrateCmd(
+    msgspec.Struct, tag=int(CmdType.CALIBRATE), array_like=True, frozen=True, gc=False
+):
+    """CALIBRATE: [CmdType.CALIBRATE]
+
+    Always runs the firmware's end-stop referencing sequence, even when the
+    robot already reports itself referenced. HOME on a referenced robot is a
+    planned return move instead.
+    """
 
     pass
 
@@ -1799,6 +1814,7 @@ __all__ = [
     "MoveSCmd",
     "MovePCmd",
     "HomeCmd",
+    "CalibrateCmd",
     "CheckpointCmd",
     # Command structs — streaming (servo/jog)
     "ServoJCmd",

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -16,11 +16,11 @@ Wire format uses msgpack arrays with integer type codes:
 
 import logging
 from dataclasses import dataclass, field
+from collections.abc import Sequence
 from enum import IntEnum, auto
 from typing import Annotated, TypeAlias, Union, cast
 
 import msgspec
-from collections.abc import Sequence
 import numpy as np
 import ormsgpack
 from numba import njit
@@ -1361,7 +1361,7 @@ def pack_status(
     homed: bool = True,
     enabled: bool = True,
     homing_step: int = 0,
-    joints_homed: "np.ndarray | Sequence[int]" = _NO_JOINTS_HOMED,
+    joints_homed: Sequence[int] = _NO_JOINTS_HOMED,
 ) -> bytes:
     """Pack a status broadcast message.
 
@@ -1460,22 +1460,21 @@ class StatusBuffer:
     # e-stop latch). True from producers that predate the field.
     enabled: bool = True
     # Remaining waldoctl StatusBuffer Protocol members. parol6 has no torque
-    # sensing, fieldbus, warning source, or homing-progress reporting, so
-    # these hold their empty values.
+    # sensing, fieldbus, or warning source, so these hold their empty values.
     torques: np.ndarray = field(default_factory=lambda: np.zeros(6, dtype=np.float64))
     torques_ext: np.ndarray = field(
         default_factory=lambda: np.zeros(6, dtype=np.float64)
     )
     warnings: list[tuple] = field(default_factory=list)
     link_health: dict = field(default_factory=dict)
-    # Firmware referencing progress (see ControllerState.homing_step) and the
-    # per-joint homed bits; `homing` is the waldoctl-shaped view of the two,
-    # rebuilt only when they change and empty while idle.
-    homing_step: int = 0
-    joints_homed: np.ndarray = field(
-        default_factory=lambda: np.zeros(6, dtype=np.int32)
-    )
+    # Firmware referencing progress in waldoctl's shape: active, sequence_step,
+    # and one (HomingJointState, HomingPhase) pair per joint; empty while idle.
     homing: dict = field(default_factory=dict)
+    # Last decoded (step, per-joint bits) so the view is rebuilt only on change.
+    _homing_step: int = field(default=0, init=False, repr=False, compare=False)
+    _homing_bits: list[int] = field(
+        default_factory=lambda: [0] * 6, init=False, repr=False, compare=False
+    )
     # Built once in __post_init__, aliasing the two enable arrays the decoder
     # mutates in place.
     cart_en: dict[str, np.ndarray] = field(init=False, repr=False, compare=False)
@@ -1532,8 +1531,6 @@ class StatusBuffer:
             accepted_index=self.accepted_index,
             homed=self.homed,
             enabled=self.enabled,
-            homing_step=self.homing_step,
-            joints_homed=self.joints_homed.copy(),
             torques=self.torques.copy(),
             torques_ext=self.torques_ext.copy(),
             warnings=list(self.warnings),
@@ -1555,24 +1552,24 @@ class HomingPhase(IntEnum):
     NONE = 0
 
 
-def _apply_homing_progress(buf: StatusBuffer, step: int, bits: "Sequence[int]") -> None:
-    """Update the homing fields in place; rebuild the dict view only on change."""
-    changed = buf.homing_step != step
-    buf.homing_step = step
-    jh = buf.joints_homed
-    for i in range(6):
-        bit = 1 if bits[i] else 0
-        if jh[i] != bit:
-            jh[i] = bit
-            changed = True
-    if not changed:
+_HOMING_JOINT_VIEW = (
+    (HomingJointState.SEEKING, HomingPhase.NONE),
+    (HomingJointState.HOMED, HomingPhase.NONE),
+)
+
+
+def _apply_homing_progress(buf: StatusBuffer, step: int, bits: list[int]) -> None:
+    """Rebuild the homing view only when the step or per-joint bits change."""
+    if step == buf._homing_step and bits == buf._homing_bits:
         return
+    buf._homing_step = step
+    buf._homing_bits[:] = bits
     if step == 0:
         buf.homing.clear()
         return
     buf.homing["active"] = True
     buf.homing["sequence_step"] = step
-    buf.homing["joints"] = [(HomingJointState(int(b)), HomingPhase.NONE) for b in jh]
+    buf.homing["joints"] = [_HOMING_JOINT_VIEW[b] for b in bits]
 
 
 def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:

--- a/parol6/protocol/wire.py
+++ b/parol6/protocol/wire.py
@@ -20,6 +20,7 @@ from enum import IntEnum, auto
 from typing import Annotated, TypeAlias, Union, cast
 
 import msgspec
+from collections.abc import Sequence
 import numpy as np
 import ormsgpack
 from numba import njit
@@ -158,8 +159,6 @@ class CmdType(IntEnum):
     SET_SHAPES = auto()
     # Collision-world readback query (installation + program layers)
     SHAPES = auto()
-    # Forced end-stop referencing (appended last: values are wire tags)
-    CALIBRATE = auto()
 
 
 # =============================================================================
@@ -502,22 +501,15 @@ class JogLCmd(
 class HomeCmd(
     msgspec.Struct, tag=int(CmdType.HOME), array_like=True, frozen=True, gc=False
 ):
-    """HOME: [CmdType.HOME]"""
+    """HOME: [CmdType.HOME, calibrate]
 
-    pass
-
-
-class CalibrateCmd(
-    msgspec.Struct, tag=int(CmdType.CALIBRATE), array_like=True, frozen=True, gc=False
-):
-    """CALIBRATE: [CmdType.CALIBRATE]
-
-    Always runs the firmware's end-stop referencing sequence, even when the
-    robot already reports itself referenced. HOME on a referenced robot is a
-    planned return move instead.
+    calibrate=True always runs the firmware's end-stop referencing sequence
+    to re-derive joint zero. Otherwise an already-referenced robot gets a
+    planned, collision-checked return move instead; the referencing sequence
+    itself is firmware-driven and ignores the collision world.
     """
 
-    pass
+    calibrate: bool = False
 
 
 class ResetCmd(
@@ -1024,6 +1016,8 @@ class LoopStatsResultStruct(
     p95_period_s: float
     p99_period_s: float
     mean_hz: float
+    p50_period_s: float = 0.0
+    p90_period_s: float = 0.0
 
 
 class ToolResultStruct(
@@ -1337,6 +1331,9 @@ def pack_response(result: Response) -> bytes:
     return _encoder.encode(ResponseMsg(result))
 
 
+_NO_JOINTS_HOMED: tuple[int, ...] = (0, 0, 0, 0, 0, 0)
+
+
 def pack_status(
     pose: np.ndarray,
     angles: np.ndarray,
@@ -1362,6 +1359,9 @@ def pack_status(
     scene_epoch: int = 0,
     accepted_index: int = -1,
     homed: bool = True,
+    enabled: bool = True,
+    homing_step: int = 0,
+    joints_homed: "np.ndarray | Sequence[int]" = _NO_JOINTS_HOMED,
 ) -> bytes:
     """Pack a status broadcast message.
 
@@ -1406,6 +1406,9 @@ def pack_status(
             scene_epoch,
             accepted_index,
             homed,
+            enabled,
+            homing_step,
+            joints_homed,
         ),
         option=ormsgpack.OPT_SERIALIZE_NUMPY,
     )
@@ -1453,6 +1456,26 @@ class StatusBuffer:
     # All joints homed. True from producers that predate the field (permissive:
     # old servers gate nothing, so claiming unhomed would be a false alarm).
     homed: bool = True
+    # Whether the controller accepts motion (False while disabled, e.g. the
+    # e-stop latch). True from producers that predate the field.
+    enabled: bool = True
+    # Remaining waldoctl StatusBuffer Protocol members. parol6 has no torque
+    # sensing, fieldbus, warning source, or homing-progress reporting, so
+    # these hold their empty values.
+    torques: np.ndarray = field(default_factory=lambda: np.zeros(6, dtype=np.float64))
+    torques_ext: np.ndarray = field(
+        default_factory=lambda: np.zeros(6, dtype=np.float64)
+    )
+    warnings: list[tuple] = field(default_factory=list)
+    link_health: dict = field(default_factory=dict)
+    # Firmware referencing progress (see ControllerState.homing_step) and the
+    # per-joint homed bits; `homing` is the waldoctl-shaped view of the two,
+    # rebuilt only when they change and empty while idle.
+    homing_step: int = 0
+    joints_homed: np.ndarray = field(
+        default_factory=lambda: np.zeros(6, dtype=np.int32)
+    )
+    homing: dict = field(default_factory=dict)
     # Built once in __post_init__, aliasing the two enable arrays the decoder
     # mutates in place.
     cart_en: dict[str, np.ndarray] = field(init=False, repr=False, compare=False)
@@ -1462,6 +1485,15 @@ class StatusBuffer:
             "WRF": self.cart_en_wrf,
             "TRF": self.cart_en_trf,
         }
+
+    @property
+    def freedrive(self) -> bool:
+        """PAROL6 steppers cannot be back-driven."""
+        return False
+
+    @property
+    def mode(self) -> ActionState:
+        return self.action_state
 
     def copy(self) -> "StatusBuffer":
         """Return a deep copy with all arrays copied."""
@@ -1499,7 +1531,48 @@ class StatusBuffer:
             scene_epoch=self.scene_epoch,
             accepted_index=self.accepted_index,
             homed=self.homed,
+            enabled=self.enabled,
+            homing_step=self.homing_step,
+            joints_homed=self.joints_homed.copy(),
+            torques=self.torques.copy(),
+            torques_ext=self.torques_ext.copy(),
+            warnings=list(self.warnings),
+            link_health=dict(self.link_health),
+            homing=dict(self.homing),
         )
+
+
+class HomingJointState(IntEnum):
+    """Per-joint firmware referencing state (StatusBuffer.homing["joints"])."""
+
+    SEEKING = 0
+    HOMED = 1
+
+
+class HomingPhase(IntEnum):
+    """PAROL6 firmware exposes no sub-phase; kept for the (state, phase) shape."""
+
+    NONE = 0
+
+
+def _apply_homing_progress(buf: StatusBuffer, step: int, bits: "Sequence[int]") -> None:
+    """Update the homing fields in place; rebuild the dict view only on change."""
+    changed = buf.homing_step != step
+    buf.homing_step = step
+    jh = buf.joints_homed
+    for i in range(6):
+        bit = 1 if bits[i] else 0
+        if jh[i] != bit:
+            jh[i] = bit
+            changed = True
+    if not changed:
+        return
+    if step == 0:
+        buf.homing.clear()
+        return
+    buf.homing["active"] = True
+    buf.homing["sequence_step"] = step
+    buf.homing["joints"] = [(HomingJointState(int(b)), HomingPhase.NONE) for b in jh]
 
 
 def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:
@@ -1511,7 +1584,7 @@ def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:
                      error, queued_segments, queued_duration, action_params,
                      tool_status_tuple, tcp_speed, simulator_active,
                      collision_active, collision_pairs, scene_epoch,
-                     accepted_index, homed]
+                     accepted_index, homed, enabled, homing_step, joints_homed]
 
     Args:
         data: Raw msgpack bytes
@@ -1583,6 +1656,9 @@ def decode_status_bin_into(data: bytes, buf: StatusBuffer) -> bool:
             buf.scene_epoch = int(msg[22])
         buf.accepted_index = int(msg[23]) if len(msg) > 23 else -1
         buf.homed = bool(msg[24]) if len(msg) > 24 else True
+        buf.enabled = bool(msg[25]) if len(msg) > 25 else True
+        if len(msg) > 27:
+            _apply_homing_progress(buf, int(msg[26]), msg[27])
 
         return True
     except Exception as e:
@@ -1814,7 +1890,8 @@ __all__ = [
     "MoveSCmd",
     "MovePCmd",
     "HomeCmd",
-    "CalibrateCmd",
+    "HomingJointState",
+    "HomingPhase",
     "CheckpointCmd",
     # Command structs — streaming (servo/jog)
     "ServoJCmd",

--- a/parol6/server/controller.py
+++ b/parol6/server/controller.py
@@ -358,6 +358,8 @@ class Controller:
                 self._executor.clear_queue("E-Stop activated")
                 state.Command_out = CommandCode.DISABLE
                 state.Speed_out.fill(0)
+                state.enabled = False
+                state.disabled_reason = "E-STOP pressed"
                 state.error = make_error(ErrorCode.SYS_ESTOP_ACTIVE)
         elif state.InOut_in[4] == 1:  # E-stop released
             if self.estop_active:

--- a/parol6/server/controller.py
+++ b/parol6/server/controller.py
@@ -464,6 +464,8 @@ class Controller:
             state.max_period_s = m.max_period_s
             state.p95_period_s = m.p95_period_s
             state.p99_period_s = m.p99_period_s
+            state.p90_period_s = m.p90_period_s
+            state.p50_period_s = m.p50_period_s
 
     def _log_periodic_status(self, state: ControllerState) -> None:
         """Log performance metrics every 3 seconds."""

--- a/parol6/server/loop_timer.py
+++ b/parol6/server/loop_timer.py
@@ -125,10 +125,7 @@ def _compute_loop_stats(
         k50 = int(n * 0.50)
         p50 = _quickselect(scratch[:n], k50)
     else:
-        p95 = max_val
-        p99 = max_val
-        p90 = max_val
-        p50 = max_val
+        p95 = p99 = p90 = p50 = max_val
 
     return mean, std, min_val, max_val, p95, p99, p90, p50
 

--- a/parol6/server/loop_timer.py
+++ b/parol6/server/loop_timer.py
@@ -80,14 +80,15 @@ def _compute_phase_stats(
 @njit(cache=True)
 def _compute_loop_stats(
     samples: np.ndarray, scratch: np.ndarray, n: int
-) -> tuple[float, float, float, float, float, float]:
+) -> tuple[float, float, float, float, float, float, float, float]:
     """Compute loop stats via single-pass Welford for mean+std.
 
     Uses the pre-allocated scratch buffer for percentiles (no hot-path alloc):
-    one copy to scratch, p99 first then p95 on the same data.
+    one copy to scratch, then p99, p95, p90, p50 in descending order on the
+    same data.
     """
     if n == 0:
-        return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
     mean = 0.0
     m2 = 0.0  # sum of squared differences
@@ -117,11 +118,19 @@ def _compute_loop_stats(
 
         k95 = int(n * 0.95)
         p95 = _quickselect(scratch[:n], k95)
+
+        k90 = int(n * 0.90)
+        p90 = _quickselect(scratch[:n], k90)
+
+        k50 = int(n * 0.50)
+        p50 = _quickselect(scratch[:n], k50)
     else:
         p95 = max_val
         p99 = max_val
+        p90 = max_val
+        p50 = max_val
 
-    return mean, std, min_val, max_val, p95, p99
+    return mean, std, min_val, max_val, p95, p99, p90, p50
 
 
 @njit(cache=True)
@@ -514,6 +523,8 @@ class LoopMetrics:
         "max_period_s",
         "p95_period_s",
         "p99_period_s",
+        "p90_period_s",
+        "p50_period_s",
         # Overshoot tracking (how much we miss the deadline by)
         "mean_overshoot_s",
         "max_overshoot_s",
@@ -543,6 +554,8 @@ class LoopMetrics:
         self.max_period_s = 0.0
         self.p95_period_s = 0.0
         self.p99_period_s = 0.0
+        self.p90_period_s = 0.0
+        self.p50_period_s = 0.0
         self.mean_overshoot_s = 0.0
         self.max_overshoot_s = 0.0
         self.p99_overshoot_s = 0.0
@@ -634,7 +647,7 @@ class LoopMetrics:
     def compute_stats(self) -> None:
         """Compute statistics from buffers."""
         if self._buffer_count > 0:
-            mean, std, min_val, max_val, p95, p99 = _compute_loop_stats(
+            mean, std, min_val, max_val, p95, p99, p90, p50 = _compute_loop_stats(
                 self._buffer, self._scratch, self._buffer_count
             )
             self.mean_period_s = mean
@@ -643,6 +656,8 @@ class LoopMetrics:
             self.max_period_s = max_val
             self.p95_period_s = p95
             self.p99_period_s = p99
+            self.p90_period_s = p90
+            self.p50_period_s = p50
 
         # overshoot only needs mean/max/p99, so reuse the simpler phase stats
         if self._overshoot_count > 0:
@@ -668,6 +683,8 @@ class LoopMetrics:
         self.max_period_s = 0.0
         self.p95_period_s = 0.0
         self.p99_period_s = 0.0
+        self.p90_period_s = 0.0
+        self.p50_period_s = 0.0
         self._overshoot_buffer.fill(0.0)
         self._overshoot_idx = 0
         self._overshoot_count = 0

--- a/parol6/server/motion_planner.py
+++ b/parol6/server/motion_planner.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Union, cast
 import numpy as np
 
 from parol6.protocol.wire import (
-    CalibrateCmd,
     HomeCmd,
     MoveJCmd,
     SelectToolCmd,
@@ -236,8 +235,13 @@ class TrajectoryPlanner:
 
         # Fast-path home: an already-referenced robot returns to the standby
         # pose with a normal planned (collision-checked) joint move instead
-        # of re-running the firmware switch-seek.
-        if isinstance(params, HomeCmd) and bool(self.state.Homed_in[:6].all()):
+        # of re-running the firmware switch-seek, unless calibration was
+        # requested explicitly.
+        if (
+            isinstance(params, HomeCmd)
+            and not params.calibrate
+            and bool(self.state.Homed_in[:6].all())
+        ):
             params = MoveJCmd(angles=self._home_deg, speed=self._home_return_speed)
 
         cmd_class = self._registry.get_command_for_struct(type(params))
@@ -500,7 +504,7 @@ class TrajectoryPlanner:
                 variant_key=self.state.current_tool_variant,
                 tcp_offset_m=offset_m,
             )
-        elif isinstance(params, (HomeCmd, CalibrateCmd)):
+        elif isinstance(params, HomeCmd):
             self.state.Position_in[:] = self._home_steps
             self.state.Homed_in.fill(1)
         elif isinstance(params, SetShapesCmd):

--- a/parol6/server/motion_planner.py
+++ b/parol6/server/motion_planner.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Union, cast
 import numpy as np
 
 from parol6.protocol.wire import (
+    CalibrateCmd,
     HomeCmd,
     MoveJCmd,
     SelectToolCmd,
@@ -499,7 +500,7 @@ class TrajectoryPlanner:
                 variant_key=self.state.current_tool_variant,
                 tcp_offset_m=offset_m,
             )
-        elif isinstance(params, HomeCmd):
+        elif isinstance(params, (HomeCmd, CalibrateCmd)):
             self.state.Position_in[:] = self._home_steps
             self.state.Homed_in.fill(1)
         elif isinstance(params, SetShapesCmd):

--- a/parol6/server/state.py
+++ b/parol6/server/state.py
@@ -241,8 +241,9 @@ class ControllerState:
     # Action tracking for status broadcast and queries
     action_current: str = ""
     action_params: str = ""
-    # Firmware referencing progress: 0 idle, 1 signalling, 2 waiting for the
-    # firmware to clear the homed bits, 3 waiting for every joint to re-home.
+    # HomeState value of the live HomeCommand (1 signalling, 2 waiting for the
+    # firmware to clear the homed bits, 3 waiting for every joint); meaningful
+    # only while action_current is "HomeCommand".
     homing_step: int = 0
     action_state: ActionState = ActionState.IDLE  # IDLE, EXECUTING, ERROR
     action_next: str = ""

--- a/parol6/server/state.py
+++ b/parol6/server/state.py
@@ -241,6 +241,9 @@ class ControllerState:
     # Action tracking for status broadcast and queries
     action_current: str = ""
     action_params: str = ""
+    # Firmware referencing progress: 0 idle, 1 signalling, 2 waiting for the
+    # firmware to clear the homed bits, 3 waiting for every joint to re-home.
+    homing_step: int = 0
     action_state: ActionState = ActionState.IDLE  # IDLE, EXECUTING, ERROR
     action_next: str = ""
     queue_nonstreamable: list[str] = field(default_factory=list)
@@ -292,6 +295,8 @@ class ControllerState:
     max_period_s: float = 0.0
     p95_period_s: float = 0.0
     p99_period_s: float = 0.0
+    p90_period_s: float = 0.0
+    p50_period_s: float = 0.0
 
     # Flag to signal loop stats reset (picked up by controller)
     loop_stats_reset_pending: bool = False
@@ -368,6 +373,7 @@ class ControllerState:
         # Action tracking
         self.action_current = ""
         self.action_params = ""
+        self.homing_step = 0
         self.action_state = ActionState.IDLE
         self.action_next = ""
         self.queue_nonstreamable.clear()

--- a/parol6/server/status_cache.py
+++ b/parol6/server/status_cache.py
@@ -166,6 +166,9 @@ class StatusCache:
 
         # All-joints-homed tracking field
         self._homed: bool = False
+        self._enabled: bool = True
+        self._homing_step: int = 0
+        self._joints_homed: np.ndarray = np.zeros(6, dtype=np.int32)
 
         # Self-collision viz tracking
         self._collision_active: bool = False
@@ -514,6 +517,19 @@ class StatusCache:
         if homed_changed:
             self._homed = homed
 
+        enabled_changed = self._enabled != state.enabled
+        if enabled_changed:
+            self._enabled = state.enabled
+
+        homing_changed = self._homing_step != state.homing_step
+        if homing_changed:
+            self._homing_step = state.homing_step
+        for i in range(6):
+            bit = 1 if state.Homed_in[i] else 0
+            if self._joints_homed[i] != bit:
+                self._joints_homed[i] = bit
+                homing_changed = True
+
         collision_changed = (
             self._collision_active != state.collision_active
             or self._collision_pairs != state.collision_pairs
@@ -542,6 +558,8 @@ class StatusCache:
             or queue_changed
             or error_changed
             or homed_changed
+            or enabled_changed
+            or homing_changed
             or collision_changed
             or depth_changed
         ):
@@ -577,6 +595,9 @@ class StatusCache:
                 scene_epoch=self._last_shapes_version,
                 accepted_index=self._accepted_index,
                 homed=self._homed,
+                enabled=self._enabled,
+                homing_step=self._homing_step,
+                joints_homed=self._joints_homed,
             )
             self._binary_dirty = False
         return self._binary_cache

--- a/parol6/server/status_cache.py
+++ b/parol6/server/status_cache.py
@@ -168,7 +168,7 @@ class StatusCache:
         self._homed: bool = False
         self._enabled: bool = True
         self._homing_step: int = 0
-        self._joints_homed: np.ndarray = np.zeros(6, dtype=np.int32)
+        self._joints_homed: list[int] = [0] * 6
 
         # Self-collision viz tracking
         self._collision_active: bool = False
@@ -507,12 +507,18 @@ class StatusCache:
         if error_changed:
             self._error = state.error
 
-        # Scalar loop keeps the 100Hz path allocation-free (no slice/temporary).
+        # One scalar pass keeps the 100Hz path allocation-free; the per-joint
+        # bits feed both the aggregate `homed` and the homing-progress view.
         homed = True
+        homing_changed = False
+        joints_homed = self._joints_homed
         for i in range(6):
-            if not state.Homed_in[i]:
+            bit = 1 if state.Homed_in[i] else 0
+            if not bit:
                 homed = False
-                break
+            if joints_homed[i] != bit:
+                joints_homed[i] = bit
+                homing_changed = True
         homed_changed = self._homed != homed
         if homed_changed:
             self._homed = homed
@@ -521,14 +527,12 @@ class StatusCache:
         if enabled_changed:
             self._enabled = state.enabled
 
-        homing_changed = self._homing_step != state.homing_step
-        if homing_changed:
-            self._homing_step = state.homing_step
-        for i in range(6):
-            bit = 1 if state.Homed_in[i] else 0
-            if self._joints_homed[i] != bit:
-                self._joints_homed[i] = bit
-                homing_changed = True
+        # Only a live HomeCommand owns homing_step; any cancel path that drops
+        # the command clears action_current, so derive "idle" from that.
+        step = state.homing_step if state.action_current == "HomeCommand" else 0
+        if self._homing_step != step:
+            self._homing_step = step
+            homing_changed = True
 
         collision_changed = (
             self._collision_active != state.collision_active

--- a/tests/integration/test_unhomed_motion_gate.py
+++ b/tests/integration/test_unhomed_motion_gate.py
@@ -44,10 +44,21 @@ def test_planned_motion_refused_until_homed(client: RobotClient, server_proc):
     assert client.move_j(target, duration=1.5, wait=True) >= 0
 
 
-def test_calibrate_rereferences_homed_robot(client: RobotClient, server_proc):
-    """calibrate() runs the real referencing sequence even when the robot is
-    already homed (home() substitutes a planned return move), and leaves the
-    robot referenced at standby."""
-    assert client.wait_status(lambda s: s.homed, timeout=5.0)
-    assert client.calibrate(wait=True, timeout=30.0) >= 0
+def test_home_calibrate_rereferences_homed_robot(client: RobotClient, server_proc):
+    """home(calibrate=True) runs the real referencing sequence even when the
+    robot is already homed — the firmware drops the homed bits while it seeks
+    the end stops, which a substituted planned return move never does — and
+    leaves the robot referenced at standby."""
+    idx = client.home(calibrate=True)
+    assert idx >= 0
+    assert client.wait_status(lambda s: not s.homed, timeout=5.0)
+    # Progress is published while the firmware seeks the end stops...
+    assert client.wait_status(
+        lambda s: bool(s.homing.get("active"))
+        and any(state.name == "SEEKING" for state, _ in s.homing["joints"]),
+        timeout=5.0,
+    )
+    assert client.wait_command(idx, timeout=30.0)
     assert client.wait_status(lambda s: s.homed, timeout=2.0)
+    # ...and the view is empty again once referencing completes.
+    assert client.wait_status(lambda s: not s.homing, timeout=2.0)

--- a/tests/integration/test_unhomed_motion_gate.py
+++ b/tests/integration/test_unhomed_motion_gate.py
@@ -42,3 +42,12 @@ def test_planned_motion_refused_until_homed(client: RobotClient, server_proc):
     assert client.home(wait=True, timeout=30.0) >= 0
     assert client.wait_status(lambda s: s.homed, timeout=2.0)
     assert client.move_j(target, duration=1.5, wait=True) >= 0
+
+
+def test_calibrate_rereferences_homed_robot(client: RobotClient, server_proc):
+    """calibrate() runs the real referencing sequence even when the robot is
+    already homed (home() substitutes a planned return move), and leaves the
+    robot referenced at standby."""
+    assert client.wait_status(lambda s: s.homed, timeout=5.0)
+    assert client.calibrate(wait=True, timeout=30.0) >= 0
+    assert client.wait_status(lambda s: s.homed, timeout=2.0)

--- a/tests/unit/test_motion_pipeline.py
+++ b/tests/unit/test_motion_pipeline.py
@@ -14,7 +14,6 @@ from parol6.config import deg_to_steps
 from parol6.protocol.wire import (
     CheckpointCmd,
     DelayCmd,
-    CalibrateCmd,
     HomeCmd,
     MoveJCmd,
     SelectToolCmd,
@@ -128,13 +127,13 @@ class TestPlannerDirect:
         np.testing.assert_allclose(seg.trajectory_steps[-1], home_steps, atol=2)
         np.testing.assert_allclose(worker.state.Position_in, home_steps, atol=2)
 
-    def test_calibrate_always_runs_referencing(self, worker, segment_queue):
-        """CALIBRATE produces an InlineSegment (the firmware referencing
-        sequence) even when already referenced — unlike HOME, which
-        fast-paths to a planned return trajectory once referenced."""
+    def test_home_calibrate_always_runs_referencing(self, worker, segment_queue):
+        """HOME(calibrate=True) produces an InlineSegment (the firmware
+        referencing sequence) even when already referenced — unlike plain
+        HOME, which fast-paths to a planned return trajectory."""
         worker.state.Position_in[:] = _deg_to_steps(W1)
         worker.process_command(
-            PlanCommand(command_index=0, params=CalibrateCmd(), homed=True)
+            PlanCommand(command_index=0, params=HomeCmd(calibrate=True), homed=True)
         )
         seg = segment_queue.get(timeout=1.0)
         assert isinstance(seg, InlineSegment)

--- a/tests/unit/test_motion_pipeline.py
+++ b/tests/unit/test_motion_pipeline.py
@@ -14,6 +14,7 @@ from parol6.config import deg_to_steps
 from parol6.protocol.wire import (
     CheckpointCmd,
     DelayCmd,
+    CalibrateCmd,
     HomeCmd,
     MoveJCmd,
     SelectToolCmd,
@@ -126,6 +127,18 @@ class TestPlannerDirect:
         assert isinstance(seg, TrajectorySegment)
         np.testing.assert_allclose(seg.trajectory_steps[-1], home_steps, atol=2)
         np.testing.assert_allclose(worker.state.Position_in, home_steps, atol=2)
+
+    def test_calibrate_always_runs_referencing(self, worker, segment_queue):
+        """CALIBRATE produces an InlineSegment (the firmware referencing
+        sequence) even when already referenced — unlike HOME, which
+        fast-paths to a planned return trajectory once referenced."""
+        worker.state.Position_in[:] = _deg_to_steps(W1)
+        worker.process_command(
+            PlanCommand(command_index=0, params=CalibrateCmd(), homed=True)
+        )
+        seg = segment_queue.get(timeout=1.0)
+        assert isinstance(seg, InlineSegment)
+        np.testing.assert_array_equal(worker.state.Position_in, _home_steps())
 
     def test_checkpoint_produces_inline_segment(self, worker, segment_queue):
         """Checkpoint should produce an InlineSegment."""


### PR DESCRIPTION
`home()` gains a `calibrate` flag, declared on the waldoctl `RobotClient` ABC (Jepson2k/waldoctl `feat/calibrate`) and implemented here:

- **Uncalibrated** (first home after power-on): `home()` runs the firmware's end-stop referencing sequence — each joint seeks its limit switch — and ends at the home position. Unchanged behavior.
- **Calibrated**: `home()` is a planned, collision-checked return to the home position (the existing fast-path). `home(calibrate=True)` re-runs the referencing sequence instead.

This is the industrial calibrate-vs-home split (KUKA "mastering", ABB "calibration", with "home" as a named pose) and covers the forced-re-reference need behind #33 without changing `home()`'s default. The referencing sequence is firmware-driven and ignores the collision world; the docstrings say so.

Also in this PR — the `RobotClient` conformance gaps that CI's `ty` has been blind to because waldoctl shipped without `py.typed` (the waldoctl branch adds the marker):

- `StatusBuffer` now satisfies waldoctl's Protocol: `enabled` is broadcast on the wire from `ControllerState.enabled` (the controller-accepts-motion flag), and the members parol6 has no data for (`torques`, `torques_ext`, `warnings`, `link_health`, `homing`, `freedrive`, `mode`) hold their documented empty values.
- `loop_stats()` returns waldoctl's `LoopStatsResult`; the loop timer now also computes p50/p90 periods, and the fieldbus/RT fields report 0/False.
- Homing progress is real, not empty: `HomeCommand` publishes its step (signalling → waiting for the firmware to clear the homed bits → waiting for every joint) and the per-joint homed bits ride the status wire, so `StatusBuffer.homing` carries `active`, `sequence_step`, and one `(HomingJointState, HomingPhase)` enum pair per joint — the shape Waldo Commander's status consumer already mirrors for par6. The dict view is rebuilt only when the step or bits change and is empty while idle.

Wire compatibility: `HomeCmd.calibrate` and the new trailing status fields (`enabled`, `homing_step`, `joints_homed`) are defaulted, so older clients and status producers keep working.

Tests: a planner unit test pins the contract (`HOME(calibrate=True)` yields an InlineSegment even when referenced); the integration test drives `home(calibrate=True)` through the real client/server path and asserts the firmware drops the homed flag mid-sequence — which a substituted planned return move never does — and that `homing` reports SEEKING joints while it runs and is empty afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QrPR5eVhd31AvFpxJKr6
