### PR TITLE
waldoctl pin -> v0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "psutil>=5.9",
     "msgspec>=0.18",
     "ormsgpack>=1.4.0",
-    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.9.0",
+    "waldoctl @ git+https://github.com/Jepson2k/waldoctl.git@v0.10.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Pins the waldoctl release that carries `home(calibrate=)` and `py.typed`; #34 implemented against it via branch-matching. Tag v0.6.0 after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QrPR5eVhd31AvFpxJKr6