### PR TITLE
Dry-run snap carries the pending blend chain

### DIFF
--- a/parol6/client/dry_run_client.py
+++ b/parol6/client/dry_run_client.py
@@ -238,14 +238,22 @@ class DryRunRobotClient:
         """Snap to angles instantly (no trajectory) — used by Home and Teleport.
 
         Both establish position references, so subsequent planned moves pass
-        the homed gate."""
-        self._planner.flush()
+        the homed gate. Blended moves still buffered in the planner are
+        planned first and lead the returned result, so their paths — and any
+        refusal — reach the caller exactly as the live controller would run
+        them before the snap."""
+        pending = [
+            r
+            for seg in self._planner.flush()
+            if (r := self._segment_to_result(seg)) is not None
+        ]
         deg = np.asarray(angles_deg, dtype=np.float64)
         deg_to_steps(deg, self._state.Position_in)
         self._planner.state.Position_in[:] = self._state.Position_in
         self._planner.state.Homed_in.fill(1)
         rad = np.radians(deg).reshape(1, -1)
-        return _build_result(rad, duration=0.0)
+        snap = _build_result(rad, duration=0.0)
+        return self._merge_results([*pending, snap]) if pending else snap
 
     def _dispatch(self, params: Any) -> DryRunResult | None:
         """Route a command struct through the trajectory planner."""

--- a/tests/unit/test_dry_run_script_compat.py
+++ b/tests/unit/test_dry_run_script_compat.py
@@ -9,6 +9,7 @@ in the docs / editor auto-complete, ensuring the dry run path doesn't diverge
 from the real client.
 """
 
+import numpy as np
 import pytest
 
 from parol6.client.dry_run_client import DryRunRobotClient
@@ -161,3 +162,17 @@ class TestDryRunHomedGate:
         result = client.home()
         assert result is not None and result.error is None
         assert result.duration == 0.0
+
+    def test_snap_carries_the_pending_blend_chain(self):
+        """A blended move still buffered when the script homes with calibrate
+        (or teleports) is planned and leads the returned result — the live
+        controller runs it before the snap, so the preview must show it."""
+        client = DryRunRobotClient(initial_joints_deg=HOME, initial_homed=True)
+        assert client.move_j(ANGLES_A, speed=0.5, r=10) is None  # buffered
+
+        result = client.home(calibrate=True)
+        assert result is not None and result.error is None
+        assert result.duration > 0.0
+        assert len(result.joint_trajectory_rad) > 1
+        assert np.allclose(np.degrees(result.end_joints_rad), HOME, atol=0.5)
+        assert client.flush() == []


### PR DESCRIPTION
`_snap_to_angles` — the dry-run path behind teleport, un-referenced home, and `home(calibrate=True)` — flushed the planner's blend buffer and then discarded what the flush produced. A blended move issued right before one of those commands vanished from the preview, along with any collision refusal it would have raised on the live controller, and the preview's next move started from the snap pose as if the blended move never happened.

The flushed results now lead the merged result (the same shape par6's dry-run `home()` already returns), so consumers get the chain in script order without having to call `flush()` themselves first.

Regression test fails on the old code (snap returned a single zero-duration pose) and passes with the fix; all dry-run unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QrPR5eVhd31AvFpxJKr6